### PR TITLE
Identity mess cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ to the documentation.
 * **Command bus:** Entry point for all command execution.
 * **Event store:** Storage of the event stream for aggregates.
   Currently there is support for these storage types.
- * In-memory
- * Files
+ * In-memory - only for test
+ * Files - only for test
  * [Microsoft SQL Server](./Documentation/ReadStores-MSSQL.md)
 * **Read models:** Denormalized representation of aggregate events
   optimized for reading fast. Currently there is support for these
   read model storage types.
-  * In-memory
+  * In-memory - only for test
   * Microsoft SQL Server
 * [**Metadata:**](./Documentation/Metadata.md)
   Additional information for each aggregate event, e.g. the IP of

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,21 @@
 ### New in 0.5 (not released yet)
 
- * Breaking: `IDomainEvent` property `AggregateId` has been renamed
-   to `AggregateIdentity` and its type changed from `string` to
-   `IIdentity`
- * Breaking: Files event store now stores its log as JSON instead of
-   an `int` in the form `{"GlobalSequenceNumber":2}`. So rename the
-   current file and put in the global sequence number to continue  
+ * POTENTIAL DATA LOSS for files event store: Files event store now
+   stores its log as JSON instead of an `int` in the form
+   `{"GlobalSequenceNumber":2}`. So rename the current file and put in the
+   global sequence number before startup
+ * Breaking: Major changes has been made regarding how the aggregate
+   identity is implemented and referenced through interfaces. These changes makes
+   it possible to access the identity type directly though all interface. Some
+   notable examples are listed here. Note that this has NO impact on how data
+   is stored!
+   - `IAggregateRoot` changed to `IAggregateRoot<TIdentity>`
+   - `ICommand<TAggregate>` changed to `ICommand<TAggregate,TIdentity>`
+   - `ICommandHandler<TAggregate,TCommand>` changed to
+     `ICommandHandler<TAggregate,TIdentity, TCommand>`
+   - `IAmReadModelFor<TEvent>` changed to
+     `IAmReadModelFor<TAggregate,TIdentity,TEvent>`
+   - `IDomainEvent<TEvent>` changed to `IDomainEvent<TAggregate,TIdentity>`  
  * New: `ICommandBus.Publish` now takes a `CancellationToken` argument
 
 

--- a/Source/EventFlow.EventStores.MsSql/MssqlEventStore.cs
+++ b/Source/EventFlow.EventStores.MsSql/MssqlEventStore.cs
@@ -63,8 +63,8 @@ namespace EventFlow.EventStores.MsSql
             _connection = connection;
         }
 
-        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate>(
-            IIdentity id,
+        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<SerializedEvent> serializedEvents,
             CancellationToken cancellationToken)
         {
@@ -142,8 +142,8 @@ namespace EventFlow.EventStores.MsSql
             return eventDataModels;
         }
 
-        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate>(
-            IIdentity id,
+        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
         {
             const string sql = @"SELECT * FROM EventFlow WHERE AggregateId = @AggregateId ORDER BY AggregateSequenceNumber ASC";

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/MsSqlIntegrationTestConfiguration.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/MsSqlIntegrationTestConfiguration.cs
@@ -52,7 +52,7 @@ namespace EventFlow.MsSql.Tests.IntegrationTests
             var resolver = eventFlowOptions
                 .ConfigureMsSql(MsSqlConfiguration.New.SetConnectionString(TestDatabase.ConnectionString))
                 .UseEventStore<MsSqlEventStore>()
-                .UseMssqlReadModel<TestAggregate, TestAggregateReadModel>()
+                .UseMssqlReadModel<TestAggregate, TestId, TestAggregateReadModel>()
                 .CreateResolver();
 
             MsSqlConnection = resolver.Resolve<IMsSqlConnection>();

--- a/Source/EventFlow.MsSql.Tests/ReadModels/TestAggregateReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/ReadModels/TestAggregateReadModel.cs
@@ -23,6 +23,7 @@
 using EventFlow.Aggregates;
 using EventFlow.ReadStores;
 using EventFlow.ReadStores.MsSql;
+using EventFlow.TestHelpers.Aggregates.Test;
 using EventFlow.TestHelpers.Aggregates.Test.Events;
 using EventFlow.TestHelpers.Aggregates.Test.ReadModels;
 
@@ -33,12 +34,12 @@ namespace EventFlow.MsSql.Tests.ReadModels
         public bool DomainErrorAfterFirstReceived { get; set; }
         public int PingsReceived { get; set; }
 
-        public void Apply(IReadModelContext context, IDomainEvent<PingEvent> e)
+        public void Apply(IReadModelContext context, IDomainEvent<TestAggregate, TestId, PingEvent> e)
         {
             PingsReceived++;
         }
 
-        public void Apply(IReadModelContext context, IDomainEvent<DomainErrorAfterFirstEvent> e)
+        public void Apply(IReadModelContext context, IDomainEvent<TestAggregate, TestId, DomainErrorAfterFirstEvent> e)
         {
             DomainErrorAfterFirstReceived = true;
         }

--- a/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -45,11 +45,12 @@ namespace EventFlow.Owin.MetadataProviders
             _owinContext = owinContext;
         }
 
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(
-            IIdentity id,
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
             IAggregateEvent aggregateEvent,
             IMetadata metadata)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             return _owinContext.Request.Headers
                 .Where(kv => !RequestHeadersToSkip.Contains(kv.Key))

--- a/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
@@ -37,11 +37,12 @@ namespace EventFlow.Owin.MetadataProviders
             _owinContext = owinContext;
         }
 
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(
-            IIdentity id,
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
             IAggregateEvent aggregateEvent,
             IMetadata metadata)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             // TODO: Handle X-Forwarded-Proto header
 

--- a/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -46,11 +46,12 @@ namespace EventFlow.Owin.MetadataProviders
             _owinContext = owinContext;
         }
 
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(
-            IIdentity id,
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
             IAggregateEvent aggregateEvent,
             IMetadata metadata)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             yield return new KeyValuePair<string, string>("remote_ip_address", _owinContext.Request.RemoteIpAddress);
 

--- a/Source/EventFlow.ReadStores.MsSql/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.ReadStores.MsSql/Extensions/EventFlowOptionsExtensions.cs
@@ -27,8 +27,9 @@ namespace EventFlow.ReadStores.MsSql.Extensions
 {
     public static class EventFlowOptionsExtensions
     {
-        public static EventFlowOptions UseMssqlReadModel<TAggregate, TReadModel>(this EventFlowOptions eventFlowOptions)
-            where TAggregate : IAggregateRoot
+        public static EventFlowOptions UseMssqlReadModel<TAggregate, TIdentity, TReadModel>(this EventFlowOptions eventFlowOptions)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
             where TReadModel : IMssqlReadModel, new()
         {
             eventFlowOptions.RegisterServices(f =>
@@ -37,7 +38,7 @@ namespace EventFlow.ReadStores.MsSql.Extensions
                     {
                         f.Register<IReadModelSqlGenerator, ReadModelSqlGenerator>(Lifetime.Singleton);
                     }
-                    f.Register<IReadModelStore<TAggregate>, MssqlReadModelStore<TAggregate, TReadModel>>();
+                    f.Register<IReadModelStore<TAggregate, TIdentity>, MssqlReadModelStore<TAggregate, TIdentity, TReadModel>>();
                 });
 
             return eventFlowOptions;

--- a/Source/EventFlow.ReadStores.MsSql/IMssqlReadModelStore.cs
+++ b/Source/EventFlow.ReadStores.MsSql/IMssqlReadModelStore.cs
@@ -24,9 +24,10 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.ReadStores.MsSql
 {
-    public interface IMssqlReadModelStore<TAggregate, TReadModel> : IReadModelStore<TAggregate>
+    public interface IMssqlReadModelStore<TAggregate, in TIdentity, TReadModel> : IReadModelStore<TAggregate, TIdentity>
         where TReadModel : IMssqlReadModel, new()
-        where TAggregate : IAggregateRoot
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
     }
 }

--- a/Source/EventFlow.ReadStores.MsSql/MssqlReadModelStore.cs
+++ b/Source/EventFlow.ReadStores.MsSql/MssqlReadModelStore.cs
@@ -31,11 +31,12 @@ using EventFlow.MsSql;
 
 namespace EventFlow.ReadStores.MsSql
 {
-    public class MssqlReadModelStore<TAggregate, TReadModel> :
-        ReadModelStore<TAggregate, TReadModel>,
-        IMssqlReadModelStore<TAggregate, TReadModel>
+    public class MssqlReadModelStore<TAggregate, TIdentity, TReadModel> :
+        ReadModelStore<TAggregate, TIdentity, TReadModel>,
+        IMssqlReadModelStore<TAggregate, TIdentity, TReadModel>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
         where TReadModel : IMssqlReadModel, new()
-        where TAggregate : IAggregateRoot
     {
         private readonly IMsSqlConnection _connection;
         private readonly IReadModelSqlGenerator _readModelSqlGenerator;
@@ -51,7 +52,7 @@ namespace EventFlow.ReadStores.MsSql
         }
 
         public override async Task UpdateReadModelAsync(
-            IIdentity id,
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
         {

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/DoesNothingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/DoesNothingCommand.cs
@@ -26,14 +26,14 @@ using EventFlow.Commands;
 
 namespace EventFlow.TestHelpers.Aggregates.Test.Commands
 {
-    public class DoesNothingCommand : Command<TestAggregate>
+    public class DoesNothingCommand : Command<TestAggregate, TestId>
     {
         public DoesNothingCommand(TestId id) : base(id)
         {
         }
     }
 
-    public class DoesNothingCommandHandler : CommandHandler<TestAggregate, DoesNothingCommand>
+    public class DoesNothingCommandHandler : CommandHandler<TestAggregate, TestId, DoesNothingCommand>
     {
         public override Task ExecuteAsync(TestAggregate aggregate, DoesNothingCommand command, CancellationToken cancellationToken)
         {

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/DomainErrorAfterFirstCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/DomainErrorAfterFirstCommand.cs
@@ -22,17 +22,16 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using EventFlow.Aggregates;
 using EventFlow.Commands;
 
 namespace EventFlow.TestHelpers.Aggregates.Test.Commands
 {
-    public class DomainErrorAfterFirstCommand : Command<TestAggregate>
+    public class DomainErrorAfterFirstCommand : Command<TestAggregate, TestId>
     {
-        public DomainErrorAfterFirstCommand(IIdentity id) : base(id) { }
+        public DomainErrorAfterFirstCommand(TestId id) : base(id) { }
     }
 
-    public class DomainErrorAfterFirstCommandHander : CommandHandler<TestAggregate, DomainErrorAfterFirstCommand>
+    public class DomainErrorAfterFirstCommandHander : CommandHandler<TestAggregate, TestId, DomainErrorAfterFirstCommand>
     {
         public override Task ExecuteAsync(TestAggregate aggregate, DomainErrorAfterFirstCommand command, CancellationToken cancellationToken)
         {

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/PingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/Commands/PingCommand.cs
@@ -22,17 +22,16 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using EventFlow.Aggregates;
 using EventFlow.Commands;
 
 namespace EventFlow.TestHelpers.Aggregates.Test.Commands
 {
-    public class PingCommand : Command<TestAggregate>
+    public class PingCommand : Command<TestAggregate, TestId>
     {
-        public PingCommand(IIdentity id) : base (id) { }
+        public PingCommand(TestId id) : base (id) { }
     }
 
-    public class PingCommandHandler : CommandHandler<TestAggregate, PingCommand>
+    public class PingCommandHandler : CommandHandler<TestAggregate, TestId, PingCommand>
     {
         public override Task ExecuteAsync(TestAggregate aggregate, PingCommand command, CancellationToken cancellationToken)
         {

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/Events/DomainErrorAfterFirstEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/Events/DomainErrorAfterFirstEvent.cs
@@ -24,7 +24,7 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.TestHelpers.Aggregates.Test.Events
 {
-    public class DomainErrorAfterFirstEvent : AggregateEvent<TestAggregate>
+    public class DomainErrorAfterFirstEvent : AggregateEvent<TestAggregate, TestId>
     {
     }
 }

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/Events/PingEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/Events/PingEvent.cs
@@ -25,7 +25,7 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.TestHelpers.Aggregates.Test.Events
 {
-    public class PingEvent : AggregateEvent<TestAggregate>
+    public class PingEvent : AggregateEvent<TestAggregate, TestId>
     {
         public Guid PingId { get; private set; }
 

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/ReadModels/ITestAggregateReadModel.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/ReadModels/ITestAggregateReadModel.cs
@@ -26,8 +26,8 @@ using EventFlow.TestHelpers.Aggregates.Test.Events;
 namespace EventFlow.TestHelpers.Aggregates.Test.ReadModels
 {
     public interface ITestAggregateReadModel :
-        IAmReadModelFor<DomainErrorAfterFirstEvent>,
-        IAmReadModelFor<PingEvent>
+        IAmReadModelFor<TestAggregate, TestId, DomainErrorAfterFirstEvent>,
+        IAmReadModelFor<TestAggregate, TestId, PingEvent>
     {
         bool DomainErrorAfterFirstReceived { get; }
         int PingsReceived { get; }

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/ReadModels/TestAggregateReadModel.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/ReadModels/TestAggregateReadModel.cs
@@ -31,12 +31,12 @@ namespace EventFlow.TestHelpers.Aggregates.Test.ReadModels
         public bool DomainErrorAfterFirstReceived { get; private set; }
         public int PingsReceived { get; private set; }
 
-        public void Apply(IReadModelContext context, IDomainEvent<DomainErrorAfterFirstEvent> e)
+        public void Apply(IReadModelContext context, IDomainEvent<TestAggregate, TestId, DomainErrorAfterFirstEvent> e)
         {
             DomainErrorAfterFirstReceived = true;
         }
 
-        public void Apply(IReadModelContext context, IDomainEvent<PingEvent> e)
+        public void Apply(IReadModelContext context, IDomainEvent<TestAggregate, TestId, PingEvent> e)
         {
             PingsReceived++;
         }

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/TestAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/TestAggregate.cs
@@ -27,7 +27,7 @@ using EventFlow.TestHelpers.Aggregates.Test.Events;
 
 namespace EventFlow.TestHelpers.Aggregates.Test
 {
-    public class TestAggregate : AggregateRoot<TestAggregate>,
+    public class TestAggregate : AggregateRoot<TestAggregate, TestId>,
         IEmit<DomainErrorAfterFirstEvent>
     {
         public bool DomainErrorAfterFirstReceived { get; private set; }

--- a/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
+++ b/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
@@ -37,10 +37,10 @@ namespace EventFlow.TestHelpers.Suites
         where TConfiguration : IntegrationTestConfiguration, new()
     {
         [Test]
-        public async Task NewAggregateCanBeLoaded()
+        public void NewAggregateCanBeLoaded()
         {
             // Act
-            var testAggregate = await EventStore.LoadAggregateAsync<TestAggregate>(TestId.New, CancellationToken.None).ConfigureAwait(false);
+            var testAggregate = EventStore.LoadAggregate<TestAggregate, TestId>(TestId.New, CancellationToken.None);
 
             // Assert
             testAggregate.Should().NotBeNull();
@@ -52,7 +52,7 @@ namespace EventFlow.TestHelpers.Suites
         {
             // Arrange
             var id = TestId.New;
-            var testAggregate = await EventStore.LoadAggregateAsync<TestAggregate>(id, CancellationToken.None).ConfigureAwait(false);
+            var testAggregate = EventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
             testAggregate.Ping();
 
             // Act
@@ -77,12 +77,12 @@ namespace EventFlow.TestHelpers.Suites
         {
             // Arrange
             var id = TestId.New;
-            var testAggregate = await EventStore.LoadAggregateAsync<TestAggregate>(id, CancellationToken.None).ConfigureAwait(false);
+            var testAggregate = EventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
             testAggregate.Ping();
             await testAggregate.CommitAsync(EventStore, CancellationToken.None).ConfigureAwait(false);
 
             // Act
-            var loadedTestAggregate = await EventStore.LoadAggregateAsync<TestAggregate>(id, CancellationToken.None).ConfigureAwait(false);
+            var loadedTestAggregate = EventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
 
             // Assert
             loadedTestAggregate.Should().NotBeNull();
@@ -97,8 +97,8 @@ namespace EventFlow.TestHelpers.Suites
             // Arrange
             var id1 = TestId.New;
             var id2 = TestId.New;
-            var aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate>(id1, CancellationToken.None).ConfigureAwait(false);
-            var aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate>(id2, CancellationToken.None).ConfigureAwait(false);
+            var aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id1, CancellationToken.None).ConfigureAwait(false);
+            var aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id2, CancellationToken.None).ConfigureAwait(false);
             aggregate1.Ping();
             aggregate2.Ping();
 
@@ -118,8 +118,8 @@ namespace EventFlow.TestHelpers.Suites
             // Arrange
             var id1 = TestId.New;
             var id2 = TestId.New;
-            var aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate>(id1, CancellationToken.None).ConfigureAwait(false);
-            var aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate>(id2, CancellationToken.None).ConfigureAwait(false);
+            var aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id1, CancellationToken.None).ConfigureAwait(false);
+            var aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id2, CancellationToken.None).ConfigureAwait(false);
             aggregate1.Ping();
             aggregate2.Ping();
             aggregate2.Ping();
@@ -127,8 +127,8 @@ namespace EventFlow.TestHelpers.Suites
             // Act
             await aggregate1.CommitAsync(EventStore, CancellationToken.None).ConfigureAwait(false);
             await aggregate2.CommitAsync(EventStore, CancellationToken.None).ConfigureAwait(false);
-            aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate>(id1, CancellationToken.None).ConfigureAwait(false);
-            aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate>(id2, CancellationToken.None).ConfigureAwait(false);
+            aggregate1 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id1, CancellationToken.None).ConfigureAwait(false);
+            aggregate2 = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id2, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             aggregate1.Version.Should().Be(1);
@@ -140,7 +140,7 @@ namespace EventFlow.TestHelpers.Suites
         {
             // Arrange
             var id = TestId.New;
-            var aggregate = await EventStore.LoadAggregateAsync<TestAggregate>(id, CancellationToken.None).ConfigureAwait(false);
+            var aggregate = await EventStore.LoadAggregateAsync<TestAggregate, TestId>(id, CancellationToken.None).ConfigureAwait(false);
 
             // Act
             await aggregate.CommitAsync(EventStore, CancellationToken.None).ConfigureAwait(false);
@@ -151,8 +151,8 @@ namespace EventFlow.TestHelpers.Suites
         {
             // Arrange
             var id = TestId.New;
-            var aggregate1 = EventStore.LoadAggregate<TestAggregate>(id, CancellationToken.None);
-            var aggregate2 = EventStore.LoadAggregate<TestAggregate>(id, CancellationToken.None);
+            var aggregate1 = EventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
+            var aggregate2 = EventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
 
             aggregate1.DomainErrorAfterFirst();
             aggregate2.DomainErrorAfterFirst();

--- a/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
+++ b/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
@@ -60,7 +60,7 @@ namespace EventFlow.TestHelpers.Suites
 
             // Assert
             domainEvents.Count.Should().Be(1);
-            var pingEvent = domainEvents.Single() as IDomainEvent<PingEvent, TestId>;
+            var pingEvent = domainEvents.Single() as IDomainEvent<TestAggregate, TestId, PingEvent>;
             pingEvent.Should().NotBeNull();
             pingEvent.AggregateIdentity.Should().Be(id);
             pingEvent.AggregateSequenceNumber.Should().Be(1);

--- a/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
+++ b/Source/EventFlow.TestHelpers/Suites/EventStoreSuite.cs
@@ -60,7 +60,7 @@ namespace EventFlow.TestHelpers.Suites
 
             // Assert
             domainEvents.Count.Should().Be(1);
-            var pingEvent = domainEvents.Single() as IDomainEvent<PingEvent>;
+            var pingEvent = domainEvents.Single() as IDomainEvent<PingEvent, TestId>;
             pingEvent.Should().NotBeNull();
             pingEvent.AggregateIdentity.Should().Be(id);
             pingEvent.AggregateSequenceNumber.Should().Be(1);

--- a/Source/EventFlow.Tests/IntegrationTests/DomainTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/DomainTests.cs
@@ -60,18 +60,18 @@ namespace EventFlow.Tests.IntegrationTests
                 .AddMetadataProvider<AddGuidMetadataProvider>()
                 .AddMetadataProvider<AddMachineNameMetadataProvider>()
                 .AddMetadataProvider<AddEventTypeMetadataProvider>()
-                .UseInMemoryReadStoreFor<TestAggregate, TestAggregateReadModel>()
+                .UseInMemoryReadStoreFor<TestAggregate, TestId, TestAggregateReadModel>()
                 .AddSubscribers(typeof(Subscriber))
                 .CreateResolver())
             {
                 var commandBus = resolver.Resolve<ICommandBus>();
                 var eventStore = resolver.Resolve<IEventStore>();
-                var readModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestAggregateReadModel>>();
+                var readModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestId, TestAggregateReadModel>>();
                 var id = TestId.New;
 
                 // Act
                 commandBus.Publish(new DomainErrorAfterFirstCommand(id));
-                var testAggregate = eventStore.LoadAggregate<TestAggregate>(id, CancellationToken.None);
+                var testAggregate = eventStore.LoadAggregate<TestAggregate, TestId>(id, CancellationToken.None);
                 var testReadModel = readModelStore.Get(id);
 
                 // Assert

--- a/Source/EventFlow.Tests/IntegrationTests/DomainTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/DomainTests.cs
@@ -41,9 +41,9 @@ namespace EventFlow.Tests.IntegrationTests
     [TestFixture]
     public class DomainTests
     {
-        public class Subscriber : ISubscribeSynchronousTo<DomainErrorAfterFirstEvent>
+        public class Subscriber : ISubscribeSynchronousTo<TestAggregate, TestId, DomainErrorAfterFirstEvent>
         {
-            public Task HandleAsync(IDomainEvent<DomainErrorAfterFirstEvent> e, CancellationToken cancellationToken)
+            public Task HandleAsync(IDomainEvent<TestAggregate, TestId, DomainErrorAfterFirstEvent> e, CancellationToken cancellationToken)
             {
                 Console.WriteLine("Subscriber got DomainErrorAfterFirstEvent");
                 return Task.FromResult(0);

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
@@ -39,7 +39,7 @@ namespace EventFlow.Tests.IntegrationTests.EventStores
     {
         public class FilesConfiguration : IntegrationTestConfiguration
         {
-            private IInMemoryReadModelStore<TestAggregate, TestAggregateReadModel> _inMemoryReadModelStore;
+            private IInMemoryReadModelStore<TestAggregate, TestId, TestAggregateReadModel> _inMemoryReadModelStore;
             private IFilesEventStoreConfiguration _configuration;
 
             public override IRootResolver CreateRootResolver(EventFlowOptions eventFlowOptions)
@@ -50,11 +50,11 @@ namespace EventFlow.Tests.IntegrationTests.EventStores
                 Directory.CreateDirectory(storePath);
 
                 var resolver = eventFlowOptions
-                    .UseInMemoryReadStoreFor<TestAggregate, TestAggregateReadModel>()
+                    .UseInMemoryReadStoreFor<TestAggregate, TestId, TestAggregateReadModel>()
                     .UseFilesEventStore(FilesEventStoreConfiguration.Create(storePath))
                     .CreateResolver();
 
-                _inMemoryReadModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestAggregateReadModel>>();
+                _inMemoryReadModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestId, TestAggregateReadModel>>();
                 _configuration = resolver.Resolve<IFilesEventStoreConfiguration>();
 
                 return resolver;

--- a/Source/EventFlow.Tests/IntegrationTests/InMemoryConfiguration.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/InMemoryConfiguration.cs
@@ -33,15 +33,15 @@ namespace EventFlow.Tests.IntegrationTests
 {
     public class InMemoryConfiguration : IntegrationTestConfiguration
     {
-        private IInMemoryReadModelStore<TestAggregate, TestAggregateReadModel> _inMemoryReadModelStore;
+        private IInMemoryReadModelStore<TestAggregate, TestId, TestAggregateReadModel> _inMemoryReadModelStore;
 
         public override IRootResolver CreateRootResolver(EventFlowOptions eventFlowOptions)
         {
             var resolver = eventFlowOptions
-                .UseInMemoryReadStoreFor<TestAggregate, TestAggregateReadModel>()
+                .UseInMemoryReadStoreFor<TestAggregate, TestId, TestAggregateReadModel>()
                 .CreateResolver();
 
-            _inMemoryReadModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestAggregateReadModel>>();
+            _inMemoryReadModelStore = resolver.Resolve<IInMemoryReadModelStore<TestAggregate, TestId, TestAggregateReadModel>>();
 
             return resolver;
         }

--- a/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
@@ -100,7 +100,7 @@ namespace EventFlow.Tests.UnitTests
         {
             _eventStoreMock
                 .Setup(s => s.StoreAsync<TestAggregate, TestId>(It.IsAny<TestId>(), It.IsAny<IReadOnlyCollection<IUncommittedEvent>>(), It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult<IReadOnlyCollection<IDomainEvent>>(Many<IDomainEvent>()));
+                .Returns(() => Task.FromResult<IReadOnlyCollection<IDomainEvent<TestAggregate, TestId>>>(Many<IDomainEvent<TestAggregate, TestId>>()));
         }
 
         private Mock<ICommandHandler<TAggregate, TIdentity, TCommand>> ArrangeCommandHandlerExists<TAggregate, TIdentity, TCommand>()

--- a/Source/EventFlow.Tests/UnitTests/EventCaches/InMemoryEventCacheTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventCaches/InMemoryEventCacheTests.cs
@@ -112,7 +112,7 @@ namespace EventFlow.Tests.UnitTests.EventCaches
 
         private IReadOnlyCollection<IDomainEvent> CreateStream()
         {
-            return Many<DomainEvent<PingEvent>>();
+            return Many<DomainEvent<PingEvent, TestId>>();
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/EventCaches/InMemoryEventCacheTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventCaches/InMemoryEventCacheTests.cs
@@ -112,7 +112,7 @@ namespace EventFlow.Tests.UnitTests.EventCaches
 
         private IReadOnlyCollection<IDomainEvent> CreateStream()
         {
-            return Many<DomainEvent<PingEvent, TestId>>();
+            return Many<DomainEvent<TestAggregate, TestId, PingEvent>>();
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -33,10 +33,10 @@ namespace EventFlow.Tests.UnitTests.EventStores
     public class EventDefinitionServiceTests : TestsFor<EventDefinitionService>
     {
         [EventVersion("Fancy", 42)]
-        public class TestEventWithLongName : AggregateEvent<IAggregateRoot> { }
-        public class TestEvent : AggregateEvent<IAggregateRoot> { }
-        public class TestEventV2 : AggregateEvent<IAggregateRoot> { }
-        public class OldTestEventV5 : AggregateEvent<IAggregateRoot> { }
+        public class TestEventWithLongName : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
+        public class TestEvent : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
+        public class TestEventV2 : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
+        public class OldTestEventV5 : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
 
         [TestCase(typeof(TestEvent), 1, "TestEvent")]
         [TestCase(typeof(TestEventV2), 2, "TestEvent")]

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventStoreTests.cs
@@ -54,7 +54,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             _eventUpgradeManagerMock = InjectMock<IEventUpgradeManager>();
 
             _eventUpgradeManagerMock
-                .Setup(m => m.Upgrade<TestAggregate>(It.IsAny<IReadOnlyCollection<IDomainEvent>>()))
+                .Setup(m => m.Upgrade<TestAggregate, TestId>(It.IsAny<IReadOnlyCollection<IDomainEvent>>()))
                 .Returns<IReadOnlyCollection<IDomainEvent>>(c => c);
             _eventJsonSerializerMock
                 .Setup(m => m.Serialize(It.IsAny<IAggregateEvent>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
@@ -72,7 +72,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             var ss = ManyUncommittedEvents(1);
 
             // Act
-            await Sut.StoreAsync<TestAggregate>(TestId.New, ss, CancellationToken.None).ConfigureAwait(false);
+            await Sut.StoreAsync<TestAggregate, TestId>(TestId.New, ss, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             _eventCacheMock.Verify(c => c.InvalidateAsync(It.IsAny<Type>(), It.IsAny<TestId>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventStoreTests.cs
@@ -54,8 +54,8 @@ namespace EventFlow.Tests.UnitTests.EventStores
             _eventUpgradeManagerMock = InjectMock<IEventUpgradeManager>();
 
             _eventUpgradeManagerMock
-                .Setup(m => m.Upgrade<TestAggregate, TestId>(It.IsAny<IReadOnlyCollection<IDomainEvent>>()))
-                .Returns<IReadOnlyCollection<IDomainEvent>>(c => c);
+                .Setup(m => m.Upgrade(It.IsAny<IReadOnlyCollection<IDomainEvent<TestAggregate, TestId>>>()))
+                .Returns<IReadOnlyCollection<IDomainEvent<TestAggregate, TestId>>>(c => c);
             _eventJsonSerializerMock
                 .Setup(m => m.Serialize(It.IsAny<IAggregateEvent>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
                 .Returns<IAggregateEvent, IEnumerable<KeyValuePair<string, string>>>(
@@ -75,7 +75,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             await Sut.StoreAsync<TestAggregate, TestId>(TestId.New, ss, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            _eventCacheMock.Verify(c => c.InvalidateAsync(It.IsAny<Type>(), It.IsAny<TestId>(), It.IsAny<CancellationToken>()), Times.Once);
+            _eventCacheMock.Verify(c => c.InvalidateAsync<TestAggregate, TestId>(It.IsAny<TestId>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private List<IUncommittedEvent> ManyUncommittedEvents(int count = 3)

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -45,8 +45,8 @@ namespace EventFlow.Tests.UnitTests.EventStores
             _domainEventFactory = new DomainEventFactory();
 
             _resolverMock
-                .Setup(r => r.Resolve<IEnumerable<IEventUpgrader<TestAggregate>>>())
-                .Returns(new IEventUpgrader<TestAggregate>[]
+                .Setup(r => r.Resolve<IEnumerable<IEventUpgrader<TestAggregate, TestId>>>())
+                .Returns(new IEventUpgrader<TestAggregate, TestId>[]
                     {
                         new UpgradeTestEventV1ToTestEventV2(_domainEventFactory),
                         new UpgradeTestEventV2ToTestEventV3(_domainEventFactory), 
@@ -61,7 +61,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             var events = new IDomainEvent[]{};
 
             // Act
-            var upgradedEvents = Sut.Upgrade<TestAggregate>(events);
+            var upgradedEvents = Sut.Upgrade<TestAggregate, TestId>(events);
 
             // Assert
             upgradedEvents.Should().BeEmpty();
@@ -80,7 +80,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 };
 
             // Act
-            var upgradedEvents = Sut.Upgrade<TestAggregate>(events);
+            var upgradedEvents = Sut.Upgrade<TestAggregate, TestId>(events);
 
             // Assert
             upgradedEvents.Count.Should().Be(3);
@@ -90,10 +90,10 @@ namespace EventFlow.Tests.UnitTests.EventStores
             }
         }
 
-        public class TestEventV1 : AggregateEvent<TestAggregate> { }
-        public class TestEventV2 : AggregateEvent<TestAggregate> { }
-        public class TestEventV3 : AggregateEvent<TestAggregate> { }
-        public class DamagedEvent : AggregateEvent<TestAggregate> { }
+        public class TestEventV1 : AggregateEvent<TestAggregate, TestId> { }
+        public class TestEventV2 : AggregateEvent<TestAggregate, TestId> { }
+        public class TestEventV3 : AggregateEvent<TestAggregate, TestId> { }
+        public class DamagedEvent : AggregateEvent<TestAggregate, TestId> { }
 
         private IDomainEvent ToDomainEvent<TAggregateEvent>(TAggregateEvent aggregateEvent)
             where TAggregateEvent : IAggregateEvent
@@ -112,7 +112,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 A<Guid>());
         }
 
-        public class UpgradeTestEventV1ToTestEventV2 : IEventUpgrader<TestAggregate>
+        public class UpgradeTestEventV1ToTestEventV2 : IEventUpgrader<TestAggregate, TestId>
         {
             private readonly IDomainEventFactory _domainEventFactory;
 
@@ -130,7 +130,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             }
         }
 
-        public class UpgradeTestEventV2ToTestEventV3 : IEventUpgrader<TestAggregate>
+        public class UpgradeTestEventV2ToTestEventV3 : IEventUpgrader<TestAggregate, TestId>
         {
             private readonly IDomainEventFactory _domainEventFactory;
 
@@ -148,7 +148,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             }
         }
 
-        public class DamagedEventRemover : IEventUpgrader<TestAggregate>
+        public class DamagedEventRemover : IEventUpgrader<TestAggregate, TestId>
         {
             public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
             {

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -86,7 +86,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
             upgradedEvents.Count.Should().Be(3);
             foreach (var upgradedEvent in upgradedEvents)
             {
-                upgradedEvent.Should().BeAssignableTo<IDomainEvent<TestEventV3>>();
+                upgradedEvent.Should().BeAssignableTo<IDomainEvent<TestAggregate, TestId, TestEventV3>>();
             }
         }
 
@@ -123,7 +123,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
 
             public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
             {
-                var testEvent1 = domainEvent as IDomainEvent<TestEventV1>;
+                var testEvent1 = domainEvent as IDomainEvent<TestAggregate, TestId, TestEventV1>;
                 yield return testEvent1 == null
                     ? domainEvent
                     : _domainEventFactory.Upgrade<TestAggregate, TestId>(domainEvent, new TestEventV2());
@@ -141,7 +141,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
 
             public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
             {
-                var testEvent2 = domainEvent as IDomainEvent<TestEventV2>;
+                var testEvent2 = domainEvent as IDomainEvent<TestAggregate, TestId, TestEventV2>;
                 yield return testEvent2 == null
                     ? domainEvent
                     : _domainEventFactory.Upgrade<TestAggregate, TestId>(domainEvent, new TestEventV3());
@@ -152,7 +152,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
         {
             public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
             {
-                var damagedEvent = domainEvent as IDomainEvent<DamagedEvent>;
+                var damagedEvent = domainEvent as IDomainEvent<TestAggregate, TestId, DamagedEvent>;
                 if (damagedEvent == null)
                 {
                     yield return domainEvent;

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -58,10 +58,10 @@ namespace EventFlow.Tests.UnitTests.EventStores
         public void EmptyListReturnsEmptyList()
         {
             // Arrange
-            var events = new IDomainEvent[]{};
+            var events = new IDomainEvent<TestAggregate, TestId>[] { };
 
             // Act
-            var upgradedEvents = Sut.Upgrade<TestAggregate, TestId>(events);
+            var upgradedEvents = Sut.Upgrade(events);
 
             // Assert
             upgradedEvents.Should().BeEmpty();
@@ -80,7 +80,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 };
 
             // Act
-            var upgradedEvents = Sut.Upgrade<TestAggregate, TestId>(events);
+            var upgradedEvents = Sut.Upgrade(events);
 
             // Assert
             upgradedEvents.Count.Should().Be(3);
@@ -95,7 +95,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
         public class TestEventV3 : AggregateEvent<TestAggregate, TestId> { }
         public class DamagedEvent : AggregateEvent<TestAggregate, TestId> { }
 
-        private IDomainEvent ToDomainEvent<TAggregateEvent>(TAggregateEvent aggregateEvent)
+        private IDomainEvent<TestAggregate, TestId> ToDomainEvent<TAggregateEvent>(TAggregateEvent aggregateEvent)
             where TAggregateEvent : IAggregateEvent
         {
             var metadata = new Metadata
@@ -121,7 +121,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 _domainEventFactory = domainEventFactory;
             }
 
-            public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
+            public IEnumerable<IDomainEvent<TestAggregate, TestId>> Upgrade(IDomainEvent<TestAggregate, TestId> domainEvent)
             {
                 var testEvent1 = domainEvent as IDomainEvent<TestAggregate, TestId, TestEventV1>;
                 yield return testEvent1 == null
@@ -139,7 +139,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 _domainEventFactory = domainEventFactory;
             }
 
-            public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
+            public IEnumerable<IDomainEvent<TestAggregate, TestId>> Upgrade(IDomainEvent<TestAggregate, TestId> domainEvent)
             {
                 var testEvent2 = domainEvent as IDomainEvent<TestAggregate, TestId, TestEventV2>;
                 yield return testEvent2 == null
@@ -150,7 +150,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
 
         public class DamagedEventRemover : IEventUpgrader<TestAggregate, TestId>
         {
-            public IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent)
+            public IEnumerable<IDomainEvent<TestAggregate, TestId>> Upgrade(IDomainEvent<TestAggregate, TestId> domainEvent)
             {
                 var damagedEvent = domainEvent as IDomainEvent<TestAggregate, TestId, DamagedEvent>;
                 if (damagedEvent == null)

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -103,7 +103,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                     Timestamp = A<DateTimeOffset>()
                 };
 
-            return _domainEventFactory.Create(
+            return _domainEventFactory.Create<TestAggregate, TestId>(
                 aggregateEvent,
                 metadata,
                 A<long>(),
@@ -126,7 +126,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 var testEvent1 = domainEvent as IDomainEvent<TestEventV1>;
                 yield return testEvent1 == null
                     ? domainEvent
-                    : _domainEventFactory.Upgrade(domainEvent, new TestEventV2());
+                    : _domainEventFactory.Upgrade<TestAggregate, TestId>(domainEvent, new TestEventV2());
             }
         }
 
@@ -144,7 +144,7 @@ namespace EventFlow.Tests.UnitTests.EventStores
                 var testEvent2 = domainEvent as IDomainEvent<TestEventV2>;
                 yield return testEvent2 == null
                     ? domainEvent
-                    : _domainEventFactory.Upgrade(domainEvent, new TestEventV3());
+                    : _domainEventFactory.Upgrade<TestAggregate, TestId>(domainEvent, new TestEventV3());
             }
         }
 

--- a/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
@@ -27,6 +27,7 @@ using EventFlow.Aggregates;
 using EventFlow.Configuration;
 using EventFlow.Subscribers;
 using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates.Test;
 using EventFlow.TestHelpers.Aggregates.Test.Events;
 using Moq;
 using NUnit.Framework;
@@ -53,7 +54,7 @@ namespace EventFlow.Tests.UnitTests.Subscribers
                 .Returns(new object[] {subscriberMock.Object});
 
             // Act
-            await Sut.DispatchAsync(new[] {A<DomainEvent<PingEvent>>()}, CancellationToken.None).ConfigureAwait(false);
+            await Sut.DispatchAsync(new[] {A<DomainEvent<PingEvent, TestId>>()}, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             subscriberMock.Verify(s => s.HandleAsync(It.IsAny<IDomainEvent<PingEvent>>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
@@ -48,16 +48,16 @@ namespace EventFlow.Tests.UnitTests.Subscribers
         public async Task SubscribersGetCalled()
         {
             // Arrange
-            var subscriberMock = new Mock<ISubscribeSynchronousTo<PingEvent>>();
+            var subscriberMock = new Mock<ISubscribeSynchronousTo<TestAggregate, TestId, PingEvent>>();
             _resolverMock
                 .Setup(r => r.ResolveAll(It.IsAny<Type>()))
                 .Returns(new object[] {subscriberMock.Object});
 
             // Act
-            await Sut.DispatchAsync(new[] {A<DomainEvent<PingEvent, TestId>>()}, CancellationToken.None).ConfigureAwait(false);
+            await Sut.DispatchAsync(new[] { A<DomainEvent<TestAggregate, TestId, PingEvent>>() }, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            subscriberMock.Verify(s => s.HandleAsync(It.IsAny<IDomainEvent<PingEvent>>(), It.IsAny<CancellationToken>()), Times.Once);
+            subscriberMock.Verify(s => s.HandleAsync(It.IsAny<IDomainEvent<TestAggregate, TestId, PingEvent>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/Source/EventFlow/Aggregates/AggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/AggregateEvent.cs
@@ -24,8 +24,9 @@ using System;
 
 namespace EventFlow.Aggregates
 {
-    public abstract class AggregateEvent<TAggregate> : IAggregateEvent
-        where TAggregate : IAggregateRoot
+    public abstract class AggregateEvent<TAggregate, TIdentity> : IAggregateEvent
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
         public Type GetAggregateType()
         {

--- a/Source/EventFlow/Aggregates/AggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/AggregateEvent.cs
@@ -20,19 +20,12 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace EventFlow.Aggregates
 {
-    public abstract class AggregateEvent<TAggregate, TIdentity> : IAggregateEvent
+    public abstract class AggregateEvent<TAggregate, TIdentity> : IAggregateEvent<TAggregate, TIdentity>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
     {
-        public Type GetAggregateType()
-        {
-            return typeof (TAggregate);
-        }
-
         public override string ToString()
         {
             return string.Format("{0}/{1}", typeof(TAggregate).Name, GetType().Name);

--- a/Source/EventFlow/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/AggregateFactory.cs
@@ -27,7 +27,9 @@ namespace EventFlow.Aggregates
 {
     public class AggregateFactory : IAggregateFactory
     {
-        public Task<TAggregate> CreateNewAggregateAsync<TAggregate>(IIdentity id) where TAggregate : IAggregateRoot
+        public Task<TAggregate> CreateNewAggregateAsync<TAggregate, TIdentity>(TIdentity id)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var aggregate = (TAggregate) Activator.CreateInstance(typeof(TAggregate), id);
             return Task.FromResult(aggregate);

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -58,7 +58,7 @@ namespace EventFlow.Aggregates
         }
 
         protected void Emit<TEvent>(TEvent aggregateEvent, IMetadata metadata = null)
-            where TEvent : AggregateEvent<TAggregate, TIdentity>
+            where TEvent : IAggregateEvent<TAggregate, TIdentity>
         {
             if (aggregateEvent == null)
             {

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -31,17 +31,18 @@ using EventFlow.Exceptions;
 
 namespace EventFlow.Aggregates
 {
-    public abstract class AggregateRoot<TAggregate> : IAggregateRoot
-        where TAggregate : AggregateRoot<TAggregate>
+    public abstract class AggregateRoot<TAggregate, TIdentity> : IAggregateRoot<TIdentity>
+        where TAggregate : AggregateRoot<TAggregate, TIdentity>
+        where TIdentity : IIdentity
     {
         private readonly List<IUncommittedEvent> _uncommittedEvents = new List<IUncommittedEvent>();
 
-        public IIdentity Id { get; private set; }
+        public TIdentity Id { get; private set; }
         public int Version { get; private set; }
         public bool IsNew { get { return Version <= 0; } }
         public IEnumerable<IAggregateEvent> UncommittedEvents { get { return _uncommittedEvents.Select(e => e.AggregateEvent); } }
 
-        protected AggregateRoot(IIdentity id)
+        protected AggregateRoot(TIdentity id)
         {
             if (id == null) throw new ArgumentNullException("id");
             if ((this as TAggregate) == null)
@@ -57,7 +58,7 @@ namespace EventFlow.Aggregates
         }
 
         protected void Emit<TEvent>(TEvent aggregateEvent, IMetadata metadata = null)
-            where TEvent : AggregateEvent<TAggregate>
+            where TEvent : AggregateEvent<TAggregate, TIdentity>
         {
             if (aggregateEvent == null)
             {
@@ -82,7 +83,7 @@ namespace EventFlow.Aggregates
 
         public async Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(IEventStore eventStore, CancellationToken cancellationToken)
         {
-            var domainEvents = await eventStore.StoreAsync<TAggregate>(
+            var domainEvents = await eventStore.StoreAsync<TAggregate, TIdentity>(
                 Id,
                 _uncommittedEvents,
                 cancellationToken)

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -27,9 +27,9 @@ namespace EventFlow.Aggregates
     public class DomainEvent<TAggregate, TIdentity, TAggregateEvent> : IDomainEvent<TAggregate, TIdentity, TAggregateEvent>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
-        where TAggregateEvent : IAggregateEvent
+        where TAggregateEvent : IAggregateEvent<TAggregate, TIdentity>
     {
-        public Type AggregateType { get { return AggregateEvent.GetAggregateType(); } }
+        public Type AggregateType { get { return typeof (TAggregate); } }
         public Type EventType { get { return typeof (TAggregateEvent); } }
 
         public int AggregateSequenceNumber { get; private set; }

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -24,8 +24,9 @@ using System;
 
 namespace EventFlow.Aggregates
 {
-    public class DomainEvent<TAggregateEvent> : IDomainEvent<TAggregateEvent>
+    public class DomainEvent<TAggregateEvent, TIdentity> : IDomainEvent<TAggregateEvent, TIdentity>
         where TAggregateEvent : IAggregateEvent
+        where TIdentity : IIdentity
     {
         public Type AggregateType { get { return AggregateEvent.GetAggregateType(); } }
         public Type EventType { get { return typeof (TAggregateEvent); } }
@@ -34,7 +35,7 @@ namespace EventFlow.Aggregates
         public Guid BatchId { get; private set; }
         public TAggregateEvent AggregateEvent { get; private set; }
         public long GlobalSequenceNumber { get; private set; }
-        public IIdentity AggregateIdentity { get; private set; }
+        public TIdentity AggregateIdentity { get; private set; }
         public IMetadata Metadata { get; private set; }
         public DateTimeOffset Timestamp { get; private set; }
 
@@ -43,7 +44,7 @@ namespace EventFlow.Aggregates
             IMetadata metadata,
             DateTimeOffset timestamp,
             long globalSequenceNumber,
-            IIdentity aggregateIdentity,
+            TIdentity aggregateIdentity,
             int aggregateSequenceNumber,
             Guid batchId)
         {
@@ -54,6 +55,11 @@ namespace EventFlow.Aggregates
             AggregateIdentity = aggregateIdentity;
             AggregateSequenceNumber = aggregateSequenceNumber;
             BatchId = batchId;
+        }
+
+        public IIdentity GetIdentity()
+        {
+            return AggregateIdentity;
         }
 
         public IAggregateEvent GetAggregateEvent()

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -24,9 +24,10 @@ using System;
 
 namespace EventFlow.Aggregates
 {
-    public class DomainEvent<TAggregateEvent, TIdentity> : IDomainEvent<TAggregateEvent, TIdentity>
-        where TAggregateEvent : IAggregateEvent
+    public class DomainEvent<TAggregate, TIdentity, TAggregateEvent> : IDomainEvent<TAggregate, TIdentity, TAggregateEvent>
+        where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
+        where TAggregateEvent : IAggregateEvent
     {
         public Type AggregateType { get { return AggregateEvent.GetAggregateType(); } }
         public Type EventType { get { return typeof (TAggregateEvent); } }

--- a/Source/EventFlow/Aggregates/IAggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/IAggregateEvent.cs
@@ -20,12 +20,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace EventFlow.Aggregates
 {
     public interface IAggregateEvent
     {
-        Type GetAggregateType();
+    }
+
+    public interface IAggregateEvent<TAggregate, TIdentity> : IAggregateEvent
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+    {
     }
 }

--- a/Source/EventFlow/Aggregates/IAggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/IAggregateFactory.cs
@@ -26,7 +26,8 @@ namespace EventFlow.Aggregates
 {
     public interface IAggregateFactory
     {
-        Task<TAggregate> CreateNewAggregateAsync<TAggregate>(IIdentity id)
-            where TAggregate : IAggregateRoot;
+        Task<TAggregate> CreateNewAggregateAsync<TAggregate, TIdentity>(TIdentity id)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -27,9 +27,10 @@ using EventFlow.EventStores;
 
 namespace EventFlow.Aggregates
 {
-    public interface IAggregateRoot
+    public interface IAggregateRoot<out TIdentity>
+        where TIdentity : IIdentity
     {
-        IIdentity Id { get; }
+        TIdentity Id { get; }
         int Version { get; }
         bool IsNew { get; }
         IEnumerable<IAggregateEvent> UncommittedEvents { get; }

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -36,6 +36,6 @@ namespace EventFlow.Aggregates
         IEnumerable<IAggregateEvent> UncommittedEvents { get; }
 
         Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(IEventStore eventStore, CancellationToken cancellationToken);
-        void ApplyEvents(IEnumerable<IAggregateEvent> domainEvents);
+        void ApplyEvents(IEnumerable<IAggregateEvent> aggregateEvents);
     }
 }

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -26,7 +26,6 @@ namespace EventFlow.Aggregates
 {
     public interface IDomainEvent
     {
-        IIdentity AggregateIdentity { get; }
         Type AggregateType { get; }
         Type EventType { get; }
         int AggregateSequenceNumber { get; }
@@ -34,6 +33,8 @@ namespace EventFlow.Aggregates
         long GlobalSequenceNumber { get; }
         IMetadata Metadata { get; }
         DateTimeOffset Timestamp { get; }
+
+        IIdentity GetIdentity();
         IAggregateEvent GetAggregateEvent();
     }
 
@@ -41,5 +42,12 @@ namespace EventFlow.Aggregates
         where TAggregateEvent : IAggregateEvent
     {
         TAggregateEvent AggregateEvent { get; }
+    }
+
+    public interface IDomainEvent<out TAggregateEvent, out TIdentity> : IDomainEvent<TAggregateEvent>
+        where TAggregateEvent : IAggregateEvent
+        where TIdentity : IIdentity
+    {
+        TIdentity AggregateIdentity { get; }
     }
 }

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -38,16 +38,18 @@ namespace EventFlow.Aggregates
         IAggregateEvent GetAggregateEvent();
     }
 
-    public interface IDomainEvent<out TAggregateEvent> : IDomainEvent
-        where TAggregateEvent : IAggregateEvent
-    {
-        TAggregateEvent AggregateEvent { get; }
-    }
-
-    public interface IDomainEvent<out TAggregateEvent, out TIdentity> : IDomainEvent<TAggregateEvent>
-        where TAggregateEvent : IAggregateEvent
+    public interface IDomainEvent<TAggregate, out TIdentity> : IDomainEvent
+        where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
     {
         TIdentity AggregateIdentity { get; }
+    }
+
+    public interface IDomainEvent<TAggregate, out TIdentity, out TAggregateEvent> : IDomainEvent<TAggregate, TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TAggregateEvent : IAggregateEvent
+    {
+        TAggregateEvent AggregateEvent { get; }
     }
 }

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -48,7 +48,7 @@ namespace EventFlow.Aggregates
     public interface IDomainEvent<TAggregate, out TIdentity, out TAggregateEvent> : IDomainEvent<TAggregate, TIdentity>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
-        where TAggregateEvent : IAggregateEvent
+        where TAggregateEvent : IAggregateEvent<TAggregate, TIdentity>
     {
         TAggregateEvent AggregateEvent { get; }
     }

--- a/Source/EventFlow/Aggregates/IEmit.cs
+++ b/Source/EventFlow/Aggregates/IEmit.cs
@@ -22,9 +22,9 @@
 
 namespace EventFlow.Aggregates
 {
-    public interface IEmit<in TDomainEvent>
-        where TDomainEvent : IAggregateEvent
+    public interface IEmit<in TAggregateEvent>
+        where TAggregateEvent : IAggregateEvent
     {
-        void Apply(TDomainEvent e);
+        void Apply(TAggregateEvent e);
     }
 }

--- a/Source/EventFlow/Commands/Command.cs
+++ b/Source/EventFlow/Commands/Command.cs
@@ -24,12 +24,13 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.Commands
 {
-    public abstract class Command<TAggregate> : ICommand<TAggregate>
-        where TAggregate : IAggregateRoot
+    public abstract class Command<TAggregate, TIdentity> : ICommand<TAggregate, TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
-        public IIdentity Id { get; private set; }
+        public TIdentity Id { get; private set; }
 
-        protected Command(IIdentity id)
+        protected Command(TIdentity id)
         {
             Id = id;
         }

--- a/Source/EventFlow/Commands/CommandHandler.cs
+++ b/Source/EventFlow/Commands/CommandHandler.cs
@@ -26,9 +26,10 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.Commands
 {
-    public abstract class CommandHandler<TAggregate, TCommand> : ICommandHandler<TAggregate, TCommand>
-        where TAggregate : IAggregateRoot
-        where TCommand : ICommand<TAggregate>
+    public abstract class CommandHandler<TAggregate, TIdentity, TCommand> : ICommandHandler<TAggregate, TIdentity, TCommand>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TCommand : ICommand<TAggregate, TIdentity>
     {
         public abstract Task ExecuteAsync(TAggregate aggregate, TCommand command, CancellationToken cancellationToken);
     }

--- a/Source/EventFlow/Commands/ICommand.cs
+++ b/Source/EventFlow/Commands/ICommand.cs
@@ -24,7 +24,6 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.Commands
 {
-    // ReSharper disable once UnusedTypeParameter
     public interface ICommand<in TAggregate, out TIdentity>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity

--- a/Source/EventFlow/Commands/ICommand.cs
+++ b/Source/EventFlow/Commands/ICommand.cs
@@ -25,9 +25,10 @@ using EventFlow.Aggregates;
 namespace EventFlow.Commands
 {
     // ReSharper disable once UnusedTypeParameter
-    public interface ICommand<in TAggregate>
-        where TAggregate : IAggregateRoot
+    public interface ICommand<in TAggregate, out TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
-        IIdentity Id { get; }
+        TIdentity Id { get; }
     }
 }

--- a/Source/EventFlow/Commands/ICommandHandler.cs
+++ b/Source/EventFlow/Commands/ICommandHandler.cs
@@ -26,9 +26,10 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.Commands
 {
-    public interface ICommandHandler<in TAggregate, in TCommand>
-        where TAggregate : IAggregateRoot
-        where TCommand : ICommand<TAggregate>
+    public interface ICommandHandler<in TAggregate, TIdentity, in TCommand>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TCommand : ICommand<TAggregate, TIdentity>
     {
         Task ExecuteAsync(TAggregate aggregate, TCommand command, CancellationToken cancellationToken);
     }

--- a/Source/EventFlow/EventCaches/IEventCache.cs
+++ b/Source/EventFlow/EventCaches/IEventCache.cs
@@ -20,7 +20,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,20 +29,23 @@ namespace EventFlow.EventCaches
 {
     public interface IEventCache
     {
-        Task InsertAsync(
-            Type aggregateType,
-            IIdentity id,
-            IReadOnlyCollection<IDomainEvent> domainEvents,
-            CancellationToken cancellationToken);
+        Task InsertAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> domainEvents,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
         
-        Task InvalidateAsync(
-            Type aggregateType,
-            IIdentity id,
-            CancellationToken cancellationToken);
-        
-        Task<IReadOnlyCollection<IDomainEvent>> GetAsync(
-            Type aggregateType,
-            IIdentity id,
-            CancellationToken cancellationToken);
+        Task InvalidateAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
+
+        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> GetAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventCaches/InMemory/InMemoryEventCache.cs
+++ b/Source/EventFlow/EventCaches/InMemory/InMemoryEventCache.cs
@@ -46,12 +46,15 @@ namespace EventFlow.EventCaches.InMemory
             _log = log;
         }
 
-        public Task InsertAsync(
-            Type aggregateType,
-            IIdentity id,
-            IReadOnlyCollection<IDomainEvent> domainEvents,
+        public Task InsertAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> domainEvents,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
+            var aggregateType = typeof (TAggregate);
+
             if (domainEvents == null) throw new ArgumentNullException("domainEvents");
             if (!domainEvents.Any()) throw new ArgumentException(string.Format(
                 "You must provide events to cache for aggregate '{0}' with ID '{1}'",
@@ -68,11 +71,13 @@ namespace EventFlow.EventCaches.InMemory
             return Task.FromResult(0);
         }
 
-        public Task InvalidateAsync(
-            Type aggregateType,
-            IIdentity id,
+        public Task InvalidateAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
+            var aggregateType = typeof (TAggregate);
             var cacheKey = GetKey(aggregateType, id);
             if (_memoryCache.Contains(cacheKey))
             {
@@ -86,13 +91,15 @@ namespace EventFlow.EventCaches.InMemory
             return Task.FromResult(0);
         }
 
-        public Task<IReadOnlyCollection<IDomainEvent>> GetAsync(
-            Type aggregateType,
-            IIdentity id,
+        public Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> GetAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
+            var aggregateType = typeof (TAggregate);
             var cacheKey = GetKey(aggregateType, id);
-            var domainEvents = _memoryCache.Get(cacheKey) as IReadOnlyCollection<IDomainEvent>;
+            var domainEvents = _memoryCache.Get(cacheKey) as IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>;
             if (domainEvents == null)
             {
                 _log.Verbose(

--- a/Source/EventFlow/EventCaches/Null/NullEventCache.cs
+++ b/Source/EventFlow/EventCaches/Null/NullEventCache.cs
@@ -20,7 +20,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,28 +29,32 @@ namespace EventFlow.EventCaches.Null
 {
     public class NullEventCache : IEventCache
     {
-        public Task InsertAsync(
-            Type aggregateType,
-            IIdentity id, IReadOnlyCollection<IDomainEvent> domainEvents,
+        public Task InsertAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> domainEvents,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             return Task.FromResult(0);
         }
 
-        public Task InvalidateAsync(
-            Type aggregateType,
-            IIdentity id,
+        public Task InvalidateAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             return Task.FromResult(0);
         }
 
-        public Task<IReadOnlyCollection<IDomainEvent>> GetAsync(
-            Type aggregateType,
-            IIdentity id,
+        public Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> GetAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
-            return Task.FromResult(null as IReadOnlyCollection<IDomainEvent>);
+            return Task.FromResult(null as IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>);
         }
     }
 }

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -73,7 +73,7 @@ namespace EventFlow.EventStores
             Type domainEventType;
             if (!_aggregateEventToDomainEventTypeMap.TryGetValue(aggregateEventType, out domainEventType))
             {
-                domainEventType = typeof (DomainEvent<>).MakeGenericType(aggregateEventType);
+                domainEventType = typeof (DomainEvent<,>).MakeGenericType(aggregateEventType, id.GetType());
                 _aggregateEventToDomainEventTypeMap[aggregateEventType] = domainEventType;
             }
 
@@ -96,7 +96,7 @@ namespace EventFlow.EventStores
                 aggregateEvent,
                 domainEvent.Metadata,
                 domainEvent.GlobalSequenceNumber,
-                domainEvent.AggregateIdentity,
+                domainEvent.GetIdentity(),
                 domainEvent.AggregateSequenceNumber,
                 domainEvent.BatchId);
         }

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -41,11 +41,12 @@ namespace EventFlow.EventStores
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity
         {
+            var aggregateType = typeof (TAggregate);
             var aggregateEventType = aggregateEvent.GetType();
             Type domainEventType;
             if (!_aggregateEventToDomainEventTypeMap.TryGetValue(aggregateEventType, out domainEventType))
             {
-                domainEventType = typeof (DomainEvent<,>).MakeGenericType(aggregateEventType, id.GetType());
+                domainEventType = typeof(DomainEvent<,,>).MakeGenericType(aggregateType, id.GetType(), aggregateEventType);
                 _aggregateEventToDomainEventTypeMap[aggregateEventType] = domainEventType;
             }
 

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using EventFlow.Aggregates;
 
 namespace EventFlow.EventStores
@@ -31,7 +30,7 @@ namespace EventFlow.EventStores
     {
         private readonly Dictionary<Type, Type> _aggregateEventToDomainEventTypeMap = new Dictionary<Type, Type>(); 
 
-        public IDomainEvent Create<TAggregate, TIdentity>(
+        public IDomainEvent<TAggregate, TIdentity> Create<TAggregate, TIdentity>(
             IAggregateEvent aggregateEvent,
             IMetadata metadata,
             long globalSequenceNumber,
@@ -50,7 +49,7 @@ namespace EventFlow.EventStores
                 _aggregateEventToDomainEventTypeMap[aggregateEventType] = domainEventType;
             }
 
-            var domainEvent = (IDomainEvent)Activator.CreateInstance(
+            var domainEvent = (IDomainEvent<TAggregate, TIdentity>)Activator.CreateInstance(
                 domainEventType,
                 aggregateEvent,
                 metadata,
@@ -63,7 +62,7 @@ namespace EventFlow.EventStores
             return domainEvent;
         }
 
-        public IDomainEvent Upgrade<TAggregate, TIdentity>(
+        public IDomainEvent<TAggregate, TIdentity> Upgrade<TAggregate, TIdentity>(
             IDomainEvent domainEvent,
             IAggregateEvent aggregateEvent)
             where TAggregate : IAggregateRoot<TIdentity>

--- a/Source/EventFlow/EventStores/EventDefinition.cs
+++ b/Source/EventFlow/EventStores/EventDefinition.cs
@@ -27,8 +27,8 @@ namespace EventFlow.EventStores
     public class EventDefinition
     {
         public int Version { get; private set; }
-        public Type Type { get; set; }
-        public string Name { get; set; }
+        public Type Type { get; private set; }
+        public string Name { get; private set; }
 
         public EventDefinition(
             int version,

--- a/Source/EventFlow/EventStores/EventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/EventJsonSerializer.cs
@@ -63,7 +63,7 @@ namespace EventFlow.EventStores
                 metadata.AggregateSequenceNumber);
         }
 
-        public IDomainEvent Deserialize<TAggregate, TIdentity>(
+        public IDomainEvent<TAggregate, TIdentity> Deserialize<TAggregate, TIdentity>(
             TIdentity id,
             ICommittedDomainEvent committedDomainEvent)
             where TAggregate : IAggregateRoot<TIdentity>

--- a/Source/EventFlow/EventStores/EventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/EventJsonSerializer.cs
@@ -25,19 +25,11 @@ using System.Globalization;
 using System.Linq;
 using EventFlow.Aggregates;
 using EventFlow.Core;
-using EventFlow.ValueObjects;
 
 namespace EventFlow.EventStores
 {
     public class EventJsonSerializer : IEventJsonSerializer
     {
-        private class DezerializeIdentity : SingleValueObject<string>, IIdentity
-        {
-            public DezerializeIdentity(string value) : base (value)
-            {
-            }
-        }
-
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IEventDefinitionService _eventDefinitionService;
         private readonly IDomainEventFactory _domainEventFactory;
@@ -71,7 +63,11 @@ namespace EventFlow.EventStores
                 metadata.AggregateSequenceNumber);
         }
 
-        public IDomainEvent Deserialize(ICommittedDomainEvent committedDomainEvent)
+        public IDomainEvent Deserialize<TAggregate, TIdentity>(
+            TIdentity id,
+            ICommittedDomainEvent committedDomainEvent)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var metadata = (IMetadata)_jsonSerializer.Deserialize<Metadata>(committedDomainEvent.Metadata);
 
@@ -81,11 +77,11 @@ namespace EventFlow.EventStores
 
             var aggregateEvent = (IAggregateEvent)_jsonSerializer.Deserialize(committedDomainEvent.Data, eventDefinition.Type);
 
-            var domainEvent = _domainEventFactory.Create(
+            var domainEvent = _domainEventFactory.Create<TAggregate, TIdentity>(
                 aggregateEvent,
                 metadata,
                 committedDomainEvent.GlobalSequenceNumber,
-                committedDomainEvent.AggregateId,
+                id,
                 committedDomainEvent.AggregateSequenceNumber,
                 committedDomainEvent.BatchId);
 

--- a/Source/EventFlow/EventStores/EventStore.cs
+++ b/Source/EventFlow/EventStores/EventStore.cs
@@ -111,7 +111,9 @@ namespace EventFlow.EventStores
                 throw;
             }
 
-            var domainEvents = committedDomainEvents.Select(EventJsonSerializer.Deserialize).ToList();
+            var domainEvents = committedDomainEvents
+                .Select(e => EventJsonSerializer.Deserialize<TAggregate, TIdentity>(id, e))
+                .ToList();
 
             await EventCache.InvalidateAsync(aggregateType, id, cancellationToken).ConfigureAwait(false);
 
@@ -146,7 +148,7 @@ namespace EventFlow.EventStores
 
             var committedDomainEvents = await LoadCommittedEventsAsync<TAggregate, TIdentity>(id, cancellationToken).ConfigureAwait(false);
             domainEvents = committedDomainEvents
-                .Select(EventJsonSerializer.Deserialize)
+                .Select(e => EventJsonSerializer.Deserialize<TAggregate, TIdentity>(id, e))
                 .ToList();
 
             if (!domainEvents.Any())

--- a/Source/EventFlow/EventStores/EventStore.cs
+++ b/Source/EventFlow/EventStores/EventStore.cs
@@ -57,11 +57,12 @@ namespace EventFlow.EventStores
             MetadataProviders = metadataProviders.ToList();
         }
 
-        public virtual async Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate>(
-            IIdentity id,
+        public virtual async Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<IUncommittedEvent> uncommittedDomainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             if (!uncommittedDomainEvents.Any())
             {
@@ -79,7 +80,7 @@ namespace EventFlow.EventStores
                 .Select(e =>
                     {
                         var metadata = MetadataProviders
-                            .SelectMany(p => p.ProvideMetadata<TAggregate>(id, e.AggregateEvent, e.Metadata))
+                            .SelectMany(p => p.ProvideMetadata<TAggregate, TIdentity>(id, e.AggregateEvent, e.Metadata))
                             .Concat(e.Metadata);
                         return EventJsonSerializer.Serialize(e.AggregateEvent, metadata);
                     })
@@ -88,7 +89,7 @@ namespace EventFlow.EventStores
             IReadOnlyCollection<ICommittedDomainEvent> committedDomainEvents;
             try
             {
-                committedDomainEvents = await CommitEventsAsync<TAggregate>(
+                committedDomainEvents = await CommitEventsAsync<TAggregate, TIdentity>(
                     id,
                     serializedEvents,
                     cancellationToken)
@@ -117,19 +118,24 @@ namespace EventFlow.EventStores
             return domainEvents;
         }
 
-        protected abstract Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate>(
-            IIdentity id, IReadOnlyCollection<SerializedEvent> serializedEvents,
+        protected abstract Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<SerializedEvent> serializedEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        protected abstract Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate>(
-            IIdentity id,
-            CancellationToken cancellationToken);
-
-        public virtual async Task<IReadOnlyCollection<IDomainEvent>> LoadEventsAsync<TAggregate>(
-            IIdentity id,
+        protected abstract Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
+
+        public virtual async Task<IReadOnlyCollection<IDomainEvent>> LoadEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var aggregateType = typeof (TAggregate);
             var domainEvents = await EventCache.GetAsync(aggregateType, id, cancellationToken).ConfigureAwait(false);
@@ -138,7 +144,7 @@ namespace EventFlow.EventStores
                 return domainEvents;
             }
 
-            var committedDomainEvents = await LoadCommittedEventsAsync<TAggregate>(id, cancellationToken).ConfigureAwait(false);
+            var committedDomainEvents = await LoadCommittedEventsAsync<TAggregate, TIdentity>(id, cancellationToken).ConfigureAwait(false);
             domainEvents = committedDomainEvents
                 .Select(EventJsonSerializer.Deserialize)
                 .ToList();
@@ -148,17 +154,18 @@ namespace EventFlow.EventStores
                 return domainEvents;
             }
 
-            domainEvents = EventUpgradeManager.Upgrade<TAggregate>(domainEvents);
+            domainEvents = EventUpgradeManager.Upgrade<TAggregate, TIdentity>(domainEvents);
 
             await EventCache.InsertAsync(aggregateType, id, domainEvents, cancellationToken).ConfigureAwait(false);
 
             return domainEvents;
         }
 
-        public virtual async Task<TAggregate> LoadAggregateAsync<TAggregate>(
-            IIdentity id,
+        public virtual async Task<TAggregate> LoadAggregateAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var aggregateType = typeof(TAggregate);
 
@@ -167,8 +174,8 @@ namespace EventFlow.EventStores
                 aggregateType.Name,
                 id);
             
-            var domainEvents = await LoadEventsAsync<TAggregate>(id, cancellationToken).ConfigureAwait(false);
-            var aggregate = await AggregateFactory.CreateNewAggregateAsync<TAggregate>(id).ConfigureAwait(false);
+            var domainEvents = await LoadEventsAsync<TAggregate, TIdentity>(id, cancellationToken).ConfigureAwait(false);
+            var aggregate = await AggregateFactory.CreateNewAggregateAsync<TAggregate, TIdentity>(id).ConfigureAwait(false);
             aggregate.ApplyEvents(domainEvents.Select(e => e.GetAggregateEvent()));
 
             Log.Verbose(
@@ -180,13 +187,16 @@ namespace EventFlow.EventStores
             return aggregate;
         }
 
-        public virtual TAggregate LoadAggregate<TAggregate>(IIdentity id, CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+        public virtual TAggregate LoadAggregate<TAggregate, TIdentity>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var aggregate = default(TAggregate);
             using (var a = AsyncHelper.Wait)
             {
-                a.Run(LoadAggregateAsync<TAggregate>(id, cancellationToken), r => aggregate = r);
+                a.Run(LoadAggregateAsync<TAggregate, TIdentity>(id, cancellationToken), r => aggregate = r);
             }
             return aggregate;
         }

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -41,8 +41,10 @@ namespace EventFlow.EventStores
             _resolver = resolver;
         }
 
-        public IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate>(IReadOnlyCollection<IDomainEvent> domainEvents)
-            where TAggregate : IAggregateRoot
+        public IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate, TIdentity>(
+            IReadOnlyCollection<IDomainEvent> domainEvents)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             if (!domainEvents.Any())
             {
@@ -51,7 +53,7 @@ namespace EventFlow.EventStores
 
             var aggreateType = typeof (TAggregate);
             var eventUpgraders = _resolver
-                    .Resolve<IEnumerable<IEventUpgrader<TAggregate>>>()
+                    .Resolve<IEnumerable<IEventUpgrader<TAggregate, TIdentity>>>()
                     .OrderBy(u => u.GetType().Name)
                     .ToList();
 

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -41,21 +41,21 @@ namespace EventFlow.EventStores
             _resolver = resolver;
         }
 
-        public IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate, TIdentity>(
-            IReadOnlyCollection<IDomainEvent> domainEvents)
+        public IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> Upgrade<TAggregate, TIdentity>(
+            IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> domainEvents)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity
         {
             if (!domainEvents.Any())
             {
-                return new List<IDomainEvent>();
+                return new IDomainEvent<TAggregate, TIdentity>[]{};
             }
 
             var aggreateType = typeof (TAggregate);
             var eventUpgraders = _resolver
-                    .Resolve<IEnumerable<IEventUpgrader<TAggregate, TIdentity>>>()
-                    .OrderBy(u => u.GetType().Name)
-                    .ToList();
+                .Resolve<IEnumerable<IEventUpgrader<TAggregate, TIdentity>>>()
+                .OrderBy(u => u.GetType().Name)
+                .ToList();
 
             if (!eventUpgraders.Any())
             {
@@ -69,7 +69,10 @@ namespace EventFlow.EventStores
                 aggreateType.Name));
 
             return domainEvents
-                .SelectMany(e => eventUpgraders.Aggregate((IEnumerable<IDomainEvent>) new []{e}, (de, up) => de.SelectMany(up.Upgrade)))
+                .SelectMany(e => eventUpgraders
+                    .Aggregate(
+                        (IEnumerable<IDomainEvent<TAggregate, TIdentity>>)new[] { e },
+                        (de, up) => de.SelectMany(up.Upgrade)))
                 .ToList();
         }
     }

--- a/Source/EventFlow/EventStores/Files/FilesEventStore.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventStore.cs
@@ -73,8 +73,8 @@ namespace EventFlow.EventStores.Files
             }
         }
 
-        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate>(
-            IIdentity id,
+        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<SerializedEvent> serializedEvents,
             CancellationToken cancellationToken)
         {
@@ -139,8 +139,8 @@ namespace EventFlow.EventStores.Files
             }
         }
 
-        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate>(
-            IIdentity id,
+        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
         {
             using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))

--- a/Source/EventFlow/EventStores/IDomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/IDomainEventFactory.cs
@@ -27,7 +27,7 @@ namespace EventFlow.EventStores
 {
     public interface IDomainEventFactory
     {
-        IDomainEvent Create<TAggregate, TIdentity>(
+        IDomainEvent<TAggregate, TIdentity> Create<TAggregate, TIdentity>(
             IAggregateEvent aggregateEvent,
             IMetadata metadata,
             long globalSequenceNumber,
@@ -37,7 +37,7 @@ namespace EventFlow.EventStores
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
 
-        IDomainEvent Upgrade<TAggregate, TIdentity>(
+        IDomainEvent<TAggregate, TIdentity> Upgrade<TAggregate, TIdentity>(
             IDomainEvent domainEvent,
             IAggregateEvent aggregateEvent)
             where TAggregate : IAggregateRoot<TIdentity>

--- a/Source/EventFlow/EventStores/IDomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/IDomainEventFactory.cs
@@ -27,24 +27,20 @@ namespace EventFlow.EventStores
 {
     public interface IDomainEventFactory
     {
-        IDomainEvent Create(
+        IDomainEvent Create<TAggregate, TIdentity>(
             IAggregateEvent aggregateEvent,
             IMetadata metadata,
             long globalSequenceNumber,
-            string aggregateId,
+            TIdentity id,
             int aggregateSequenceNumber,
-            Guid batchId);
+            Guid batchId)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        IDomainEvent Create(
-            IAggregateEvent aggregateEvent,
-            IMetadata metadata,
-            long globalSequenceNumber,
-            IIdentity id,
-            int aggregateSequenceNumber,
-            Guid batchId);
-
-        IDomainEvent Upgrade(
+        IDomainEvent Upgrade<TAggregate, TIdentity>(
             IDomainEvent domainEvent,
-            IAggregateEvent aggregateEvent);
+            IAggregateEvent aggregateEvent)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventStores/IEventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/IEventJsonSerializer.cs
@@ -27,7 +27,14 @@ namespace EventFlow.EventStores
 {
     public interface IEventJsonSerializer
     {
-        SerializedEvent Serialize(IAggregateEvent aggregateEvent, IEnumerable<KeyValuePair<string, string>> metadatas);
-        IDomainEvent Deserialize(ICommittedDomainEvent committedDomainEvent);
+        SerializedEvent Serialize(
+            IAggregateEvent aggregateEvent,
+            IEnumerable<KeyValuePair<string, string>> metadatas);
+
+        IDomainEvent Deserialize<TAggregate, TIdentity>(
+            TIdentity id,
+            ICommittedDomainEvent committedDomainEvent)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventStores/IEventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/IEventJsonSerializer.cs
@@ -31,7 +31,7 @@ namespace EventFlow.EventStores
             IAggregateEvent aggregateEvent,
             IEnumerable<KeyValuePair<string, string>> metadatas);
 
-        IDomainEvent Deserialize<TAggregate, TIdentity>(
+        IDomainEvent<TAggregate, TIdentity> Deserialize<TAggregate, TIdentity>(
             TIdentity id,
             ICommittedDomainEvent committedDomainEvent)
             where TAggregate : IAggregateRoot<TIdentity>

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -29,14 +29,14 @@ namespace EventFlow.EventStores
 {
     public interface IEventStore
     {
-        Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate, TIdentity>(
+        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> StoreAsync<TAggregate, TIdentity>(
             TIdentity id,
             IReadOnlyCollection<IUncommittedEvent> uncommittedDomainEvents,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
 
-        Task<IReadOnlyCollection<IDomainEvent>> LoadEventsAsync<TAggregate, TIdentity>(
+        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> LoadEventsAsync<TAggregate, TIdentity>(
             TIdentity id,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -29,25 +29,29 @@ namespace EventFlow.EventStores
 {
     public interface IEventStore
     {
-        Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate>(
-            IIdentity id,
+        Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<IUncommittedEvent> uncommittedDomainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        Task<IReadOnlyCollection<IDomainEvent>> LoadEventsAsync<TAggregate>(
-            IIdentity id,
+        Task<IReadOnlyCollection<IDomainEvent>> LoadEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        Task<TAggregate> LoadAggregateAsync<TAggregate>(
-            IIdentity id,
+        Task<TAggregate> LoadAggregateAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        TAggregate LoadAggregate<TAggregate>(
-            IIdentity id,
+        TAggregate LoadAggregate<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventStores/IEventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/IEventUpgradeManager.cs
@@ -27,7 +27,8 @@ namespace EventFlow.EventStores
 {
     public interface IEventUpgradeManager
     {
-        IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate>(IReadOnlyCollection<IDomainEvent> domainEvents)
-            where TAggregate : IAggregateRoot;
+        IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate, TIdentity>(IReadOnlyCollection<IDomainEvent> domainEvents)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventStores/IEventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/IEventUpgradeManager.cs
@@ -27,7 +27,8 @@ namespace EventFlow.EventStores
 {
     public interface IEventUpgradeManager
     {
-        IReadOnlyCollection<IDomainEvent> Upgrade<TAggregate, TIdentity>(IReadOnlyCollection<IDomainEvent> domainEvents)
+        IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> Upgrade<TAggregate, TIdentity>(
+            IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>> domainEvents)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
     }

--- a/Source/EventFlow/EventStores/IEventUpgrader.cs
+++ b/Source/EventFlow/EventStores/IEventUpgrader.cs
@@ -30,8 +30,9 @@ namespace EventFlow.EventStores
         IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent);
     }
 
-    public interface IEventUpgrader<TAggregate> : IEventUpgrader
-        where TAggregate : IAggregateRoot
+    public interface IEventUpgrader<TAggregate, TIdentity> : IEventUpgrader
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
     }
 }

--- a/Source/EventFlow/EventStores/IEventUpgrader.cs
+++ b/Source/EventFlow/EventStores/IEventUpgrader.cs
@@ -25,14 +25,10 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.EventStores
 {
-    public interface IEventUpgrader
-    {
-        IEnumerable<IDomainEvent> Upgrade(IDomainEvent domainEvent);
-    }
-
-    public interface IEventUpgrader<TAggregate, TIdentity> : IEventUpgrader
+    public interface IEventUpgrader<TAggregate, TIdentity>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
     {
+        IEnumerable<IDomainEvent<TAggregate, TIdentity>> Upgrade(IDomainEvent<TAggregate, TIdentity> domainEvent);
     }
 }

--- a/Source/EventFlow/EventStores/IMetadataProvider.cs
+++ b/Source/EventFlow/EventStores/IMetadataProvider.cs
@@ -27,7 +27,11 @@ namespace EventFlow.EventStores
 {
     public interface IMetadataProvider
     {
-        IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(IIdentity id, IAggregateEvent aggregateEvent, IMetadata metadata)
-            where TAggregate : IAggregateRoot;
+        IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
+            IAggregateEvent aggregateEvent,
+            IMetadata metadata)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/EventStores/InMemory/InMemoryEventStore.cs
+++ b/Source/EventFlow/EventStores/InMemory/InMemoryEventStore.cs
@@ -73,8 +73,8 @@ namespace EventFlow.EventStores.InMemory
         {
         }
 
-        protected async override Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate>(
-            IIdentity id,
+        protected async override Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<SerializedEvent> serializedEvents,
             CancellationToken cancellationToken)
         {
@@ -129,8 +129,8 @@ namespace EventFlow.EventStores.InMemory
             }
         }
 
-        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate>(
-            IIdentity id,
+        protected override async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
             CancellationToken cancellationToken)
         {
             using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
@@ -36,7 +36,7 @@ namespace EventFlow.Extensions
         {
             var commandHandlerTypes = fromAssembly
                 .GetTypes()
-                .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ICommandHandler<,>)));
+                .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ICommandHandler<,,>)));
             return eventFlowOptions
                 .AddCommandHandlers(commandHandlerTypes);
         }
@@ -58,7 +58,7 @@ namespace EventFlow.Extensions
                 var t = commandHandlerType;
                 var handlesCommandTypes = t
                     .GetInterfaces()
-                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ICommandHandler<,>))
+                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ICommandHandler<,,>))
                     .ToList();
                 if (!handlesCommandTypes.Any())
                 {

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -58,8 +58,7 @@ namespace EventFlow.Extensions
         {
             var eventUpgraderTypes = fromAssembly
                 .GetTypes()
-                .Where(t => typeof (IEventUpgrader).IsAssignableFrom(t))
-                .ToList();
+                .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEventUpgrader<,>)));
             return eventFlowOptions
                 .AddEventUpgraders(eventUpgraderTypes);
         }

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -32,19 +32,21 @@ namespace EventFlow.Extensions
 {
     public static class EventFlowOptionsEventUpgradersExtensions
     {
-        public static EventFlowOptions AddEventUpgrader<TAggregate, TEventUpgrader>(
+        public static EventFlowOptions AddEventUpgrader<TAggregate, TIdentity, TEventUpgrader>(
             this EventFlowOptions eventFlowOptions)
-            where TAggregate : IAggregateRoot
-            where TEventUpgrader : class, IEventUpgrader<TAggregate>
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TEventUpgrader : class, IEventUpgrader<TAggregate, TIdentity>
         {
-            eventFlowOptions.RegisterServices(f => f.Register<IEventUpgrader<TAggregate>, TEventUpgrader>());
+            eventFlowOptions.RegisterServices(f => f.Register<IEventUpgrader<TAggregate, TIdentity>, TEventUpgrader>());
             return eventFlowOptions;
         }
 
-        public static EventFlowOptions AddEventUpgrader<TAggregate>(
+        public static EventFlowOptions AddEventUpgrader<TAggregate, TIdentity>(
             this EventFlowOptions eventFlowOptions,
-            Func<IResolverContext, IEventUpgrader<TAggregate>> factory)
-            where TAggregate : IAggregateRoot
+            Func<IResolverContext, IEventUpgrader<TAggregate, TIdentity>> factory)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             eventFlowOptions.RegisterServices(f => f.Register(factory));
             return eventFlowOptions;
@@ -79,11 +81,11 @@ namespace EventFlow.Extensions
                 var t = eventUpgraderType;
                 var eventUpgraderForAggregateType = t
                     .GetInterfaces()
-                    .SingleOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (IEventUpgrader<>));
+                    .SingleOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (IEventUpgrader<,>));
                 if (eventUpgraderForAggregateType == null)
                 {
                     throw new ArgumentException(string.Format(
-                        "Type '{0}' does not have the IEventUpgrader<TAggregate> interface",
+                        "Type '{0}' does not have the IEventUpgrader<TAggregate, TIdentity> interface",
                         eventUpgraderType.Name));
                 }
 

--- a/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
@@ -29,29 +29,31 @@ namespace EventFlow.Extensions
 {
     public static class EventFlowOptionsReadStoresExtensions
     {
-        public static EventFlowOptions UseInMemoryReadStoreFor<TAggregate, TReadModel>(
+        public static EventFlowOptions UseInMemoryReadStoreFor<TAggregate, TIdentity, TReadModel>(
             this EventFlowOptions eventFlowOptions)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
             where TReadModel : IReadModel, new()
         {
-            eventFlowOptions.AddReadModelStore<TAggregate, IInMemoryReadModelStore<TAggregate, TReadModel>>();
-            eventFlowOptions.RegisterServices(f => f.Register<IInMemoryReadModelStore<TAggregate, TReadModel>, InMemoryReadModelStore<TAggregate, TReadModel>>(Lifetime.Singleton));
+            eventFlowOptions.AddReadModelStore<TAggregate, TIdentity, IInMemoryReadModelStore<TAggregate, TIdentity, TReadModel>>();
+            eventFlowOptions.RegisterServices(f => f.Register<IInMemoryReadModelStore<TAggregate, TIdentity, TReadModel>, InMemoryReadModelStore<TAggregate, TIdentity, TReadModel>>(Lifetime.Singleton));
             return eventFlowOptions;
         }
 
-        public static EventFlowOptions AddReadModelStore<TAggregate, TReadModelStore>(
+        public static EventFlowOptions AddReadModelStore<TAggregate, TIdentity, TReadModelStore>(
             this EventFlowOptions eventFlowOptions,
             Lifetime lifetime = Lifetime.AlwaysUnique)
-            where TAggregate : IAggregateRoot
-            where TReadModelStore : class, IReadModelStore<TAggregate>
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TReadModelStore : class, IReadModelStore<TAggregate, TIdentity>
         {
             if (typeof(TReadModelStore).IsInterface)
             {
-                eventFlowOptions.RegisterServices(f => f.Register<IReadModelStore<TAggregate>>(r => r.Resolver.Resolve<TReadModelStore>(), lifetime));
+                eventFlowOptions.RegisterServices(f => f.Register<IReadModelStore<TAggregate, TIdentity>>(r => r.Resolver.Resolve<TReadModelStore>(), lifetime));
             }
             else
             {
-                eventFlowOptions.RegisterServices(f => f.Register<IReadModelStore<TAggregate>, TReadModelStore>(lifetime));
+                eventFlowOptions.RegisterServices(f => f.Register<IReadModelStore<TAggregate, TIdentity>, TReadModelStore>(lifetime));
             }
 
             return eventFlowOptions;

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -31,13 +31,15 @@ namespace EventFlow.Extensions
 {
     public static class EventFlowOptionsSubscriberExtensions
     {
-        public static EventFlowOptions AddSubscriber<TEvent, TSubscriber>(
+        public static EventFlowOptions AddSubscriber<TAggregate, TIdentity, TEvent, TSubscriber>(
             this EventFlowOptions eventFlowOptions)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
             where TEvent : IAggregateEvent
-            where TSubscriber : class, ISubscribeSynchronousTo<TEvent>
+            where TSubscriber : class, ISubscribeSynchronousTo<TAggregate, TIdentity, TEvent>
         {
             return eventFlowOptions
-                .RegisterServices(sr => sr.Register<ISubscribeSynchronousTo<TEvent>, TSubscriber>());
+                .RegisterServices(sr => sr.Register<ISubscribeSynchronousTo<TAggregate, TIdentity, TEvent>, TSubscriber>());
         }
 
         public static EventFlowOptions AddSubscribers(
@@ -54,7 +56,7 @@ namespace EventFlow.Extensions
         {
             var subscribeSynchronousToTypes = fromAssembly
                 .GetTypes()
-                .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ISubscribeSynchronousTo<>)));
+                .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ISubscribeSynchronousTo<,,>)));
             return eventFlowOptions
                 .AddSubscribers(subscribeSynchronousToTypes);
         }
@@ -68,7 +70,7 @@ namespace EventFlow.Extensions
                 var t = subscribeSynchronousToType;
                 var subscribeTos = t
                     .GetInterfaces()
-                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ISubscribeSynchronousTo<>))
+                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (ISubscribeSynchronousTo<,,>))
                     .ToList();
                 if (!subscribeTos.Any())
                 {

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -35,7 +35,7 @@ namespace EventFlow.Extensions
             this EventFlowOptions eventFlowOptions)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity
-            where TEvent : IAggregateEvent
+            where TEvent : IAggregateEvent<TAggregate, TIdentity>
             where TSubscriber : class, ISubscribeSynchronousTo<TAggregate, TIdentity, TEvent>
         {
             return eventFlowOptions

--- a/Source/EventFlow/ICommandBus.cs
+++ b/Source/EventFlow/ICommandBus.cs
@@ -29,10 +29,15 @@ namespace EventFlow
 {
     public interface ICommandBus
     {
-        Task PublishAsync<TAggregate>(ICommand<TAggregate> command, CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+        Task PublishAsync<TAggregate, TIdentity>(
+            ICommand<TAggregate, TIdentity> command,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
 
-        void Publish<TAggregate>(ICommand<TAggregate> command)
-            where TAggregate : IAggregateRoot;
+        void Publish<TAggregate, TIdentity>(
+            ICommand<TAggregate, TIdentity> command)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
@@ -28,7 +28,12 @@ namespace EventFlow.MetadataProviders
 {
     public class AddEventTypeMetadataProvider : IMetadataProvider
     {
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(IIdentity id, IAggregateEvent aggregateEvent, IMetadata metadata) where TAggregate : IAggregateRoot
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
+            IAggregateEvent aggregateEvent,
+            IMetadata metadata)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var aggregateEventType = aggregateEvent.GetType();
             var assembly = aggregateEventType.Assembly;

--- a/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
@@ -32,8 +32,12 @@ namespace EventFlow.MetadataProviders
     /// </summary>
     public class AddGuidMetadataProvider : IMetadataProvider
     {
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(IIdentity id, IAggregateEvent aggregateEvent, IMetadata metadata)
-            where TAggregate : IAggregateRoot
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
+            IAggregateEvent aggregateEvent,
+            IMetadata metadata)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             yield return new KeyValuePair<string, string>("guid", Guid.NewGuid().ToString());
         }

--- a/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
@@ -39,7 +39,12 @@ namespace EventFlow.MetadataProviders
                 };
         }
 
-        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate>(IIdentity id, IAggregateEvent aggregateEvent, IMetadata metadata) where TAggregate : IAggregateRoot
+        public IEnumerable<KeyValuePair<string, string>> ProvideMetadata<TAggregate, TIdentity>(
+            TIdentity id,
+            IAggregateEvent aggregateEvent,
+            IMetadata metadata)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             return Metadata;
         }

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -27,7 +27,7 @@ namespace EventFlow.ReadStores
     public interface IAmReadModelFor<TAggregate, in TIdentity, in TEvent>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
-        where TEvent : IAggregateEvent
+        where TEvent : IAggregateEvent<TAggregate, TIdentity>
     {
         void Apply(IReadModelContext context, IDomainEvent<TAggregate, TIdentity, TEvent> e);
     }

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -24,16 +24,11 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.ReadStores
 {
-    public interface IAmReadModelFor<in TEvent>
-        where TEvent : IAggregateEvent
-    {
-        void Apply(IReadModelContext context, IDomainEvent<TEvent> e);
-    }
-
-    public interface IAmReadModelFor<in TEvent, in TIdentity>
-        where TEvent : IAggregateEvent
+    public interface IAmReadModelFor<TAggregate, in TIdentity, in TEvent>
+        where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
+        where TEvent : IAggregateEvent
     {
-        void Apply(IReadModelContext context, IDomainEvent<TEvent, TIdentity> e);
+        void Apply(IReadModelContext context, IDomainEvent<TAggregate, TIdentity, TEvent> e);
     }
 }

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -29,4 +29,11 @@ namespace EventFlow.ReadStores
     {
         void Apply(IReadModelContext context, IDomainEvent<TEvent> e);
     }
+
+    public interface IAmReadModelFor<in TEvent, in TIdentity>
+        where TEvent : IAggregateEvent
+        where TIdentity : IIdentity
+    {
+        void Apply(IReadModelContext context, IDomainEvent<TEvent, TIdentity> e);
+    }
 }

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -27,11 +27,12 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.ReadStores
 {
-    public interface IReadModelStore<TAggregate>
-        where TAggregate : IAggregateRoot
+    public interface IReadModelStore<TAggregate, in TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
     {
         Task UpdateReadModelAsync(
-            IIdentity id,
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken);
     }

--- a/Source/EventFlow/ReadStores/IReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/IReadStoreManager.cs
@@ -29,10 +29,11 @@ namespace EventFlow.ReadStores
 {
     public interface IReadStoreManager
     {
-        Task UpdateReadStoresAsync<TAggregate>(
-            IIdentity id,
+        Task UpdateReadStoresAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/ReadStores/InMemory/IInMemoryReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/IInMemoryReadModelStore.cs
@@ -26,8 +26,9 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.ReadStores.InMemory
 {
-    public interface IInMemoryReadModelStore<TAggregate, out TReadModel> : IReadModelStore<TAggregate>
-        where TAggregate : IAggregateRoot
+    public interface IInMemoryReadModelStore<TAggregate, in TIdentity, out TReadModel> : IReadModelStore<TAggregate, TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
         where TReadModel : IReadModel, new()
     {
         TReadModel Get(IIdentity id);

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryReadModelStore.cs
@@ -30,11 +30,12 @@ using EventFlow.Logs;
 
 namespace EventFlow.ReadStores.InMemory
 {
-    public class InMemoryReadModelStore<TAggregate, TReadModel> :
-        ReadModelStore<TAggregate, TReadModel>,
-        IInMemoryReadModelStore<TAggregate, TReadModel>
+    public class InMemoryReadModelStore<TAggregate, TIdentity, TReadModel> :
+        ReadModelStore<TAggregate, TIdentity, TReadModel>,
+        IInMemoryReadModelStore<TAggregate, TIdentity, TReadModel>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
         where TReadModel : IReadModel, new()
-        where TAggregate : IAggregateRoot
     {
         private readonly Dictionary<string, TReadModel> _readModels = new Dictionary<string, TReadModel>();
 
@@ -45,7 +46,7 @@ namespace EventFlow.ReadStores.InMemory
         }
 
         public override Task UpdateReadModelAsync(
-            IIdentity id,
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
         {

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -30,15 +30,16 @@ using EventFlow.Logs;
 
 namespace EventFlow.ReadStores
 {
-    public abstract class ReadModelStore<TAggregate, TReadModel> : IReadModelStore<TAggregate>
-        where TAggregate : IAggregateRoot
+    public abstract class ReadModelStore<TAggregate, TIdentity, TReadModel> : IReadModelStore<TAggregate, TIdentity>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
         where TReadModel : IReadModel
     {
         private static readonly ConcurrentDictionary<Type, Action<TReadModel, IReadModelContext, IDomainEvent>> ApplyMethods = new ConcurrentDictionary<Type, Action<TReadModel, IReadModelContext, IDomainEvent>>();
 
         protected ILog Log { get; private set; }
 
-        public abstract Task UpdateReadModelAsync(IIdentity id, IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken);
+        public abstract Task UpdateReadModelAsync(TIdentity id, IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken);
 
         protected ReadModelStore(ILog log)
         {

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -48,6 +48,8 @@ namespace EventFlow.ReadStores
 
         protected void ApplyEvents(TReadModel readModel, IEnumerable<IDomainEvent> domainEvents)
         {
+            var aggregateType = typeof (TAggregate);
+            var identityType = typeof (TIdentity);
             var readModelType = typeof(TReadModel);
             var readModelContextType = typeof(IReadModelContext);
             var readModelContext = new ReadModelContext();
@@ -58,7 +60,7 @@ namespace EventFlow.ReadStores
                     domainEvent.EventType,
                     t =>
                         {
-                            var domainEventType = typeof(IDomainEvent<>).MakeGenericType(t);
+                            var domainEventType = typeof(IDomainEvent<,,>).MakeGenericType(aggregateType, identityType, t);
                             var methodInfo = readModelType.GetMethod("Apply", new[] { readModelContextType, domainEventType });
                             return  methodInfo == null
                                 ? (r ,c, e) => Log.Warning("Read model '{0}' does not handle event '{1}'", readModelType.Name, t.Name)

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -44,25 +44,27 @@ namespace EventFlow.ReadStores
             _resolver = resolver;
         }
 
-        public async Task UpdateReadStoresAsync<TAggregate>(
-            IIdentity id,
+        public async Task UpdateReadStoresAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
-            var readModelStores = _resolver.Resolve<IEnumerable<IReadModelStore<TAggregate>>>().ToList();
+            var readModelStores = _resolver.Resolve<IEnumerable<IReadModelStore<TAggregate, TIdentity>>>().ToList();
             var updateTasks = readModelStores
                 .Select(s => UpdateReadStoreAsync(s, id, domainEvents, cancellationToken))
                 .ToArray();
             await Task.WhenAll(updateTasks).ConfigureAwait(false);
         }
 
-        private async Task UpdateReadStoreAsync<TAggregate>(
-            IReadModelStore<TAggregate> readModelStore,
-            IIdentity id,
+        private async Task UpdateReadStoreAsync<TAggregate, TIdentity>(
+            IReadModelStore<TAggregate, TIdentity> readModelStore,
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             var readModelStoreType = readModelStore.GetType();
             var aggregateType = typeof(TAggregate);

--- a/Source/EventFlow/Subscribers/DomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/DomainEventPublisher.cs
@@ -41,14 +41,15 @@ namespace EventFlow.Subscribers
             _readStoreManager = readStoreManager;
         }
 
-        public async Task PublishAsync<TAggregate>(
-            IIdentity id,
+        public async Task PublishAsync<TAggregate, TIdentity>(
+            TIdentity id,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
         {
             // ARGH, dilemma, should we pass the cancellation token to read model update or not?
-            var readStoreTask = _readStoreManager.UpdateReadStoresAsync<TAggregate>(id, domainEvents, CancellationToken.None);
+            var readStoreTask = _readStoreManager.UpdateReadStoresAsync<TAggregate, TIdentity>(id, domainEvents, CancellationToken.None);
 
             var subscriberTask = _dispatchToEventSubscribers.DispatchAsync(domainEvents, cancellationToken);
 

--- a/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
@@ -29,7 +29,11 @@ namespace EventFlow.Subscribers
 {
     public interface IDomainEventPublisher
     {
-        Task PublishAsync<TAggregate>(IIdentity id, IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-            where TAggregate : IAggregateRoot;
+        Task PublishAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<IDomainEvent> domainEvents,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
     }
 }

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -26,16 +26,11 @@ using EventFlow.Aggregates;
 
 namespace EventFlow.Subscribers
 {
-    public interface ISubscribeSynchronousTo<in TEvent>
-        where TEvent : IAggregateEvent
-    {
-        Task HandleAsync(IDomainEvent<TEvent> e, CancellationToken cancellationToken);
-    }
-
-    public interface ISubscribeSynchronousTo<in TEvent, in TIdentity>
-        where TEvent : IAggregateEvent
+    public interface ISubscribeSynchronousTo<TAggregate, in TIdentity, in TEvent>
+        where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
+        where TEvent : IAggregateEvent
     {
-        Task HandleAsync(IDomainEvent<TEvent, TIdentity> e, CancellationToken cancellationToken);
+        Task HandleAsync(IDomainEvent<TAggregate, TIdentity, TEvent> e, CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -31,4 +31,11 @@ namespace EventFlow.Subscribers
     {
         Task HandleAsync(IDomainEvent<TEvent> e, CancellationToken cancellationToken);
     }
+
+    public interface ISubscribeSynchronousTo<in TEvent, in TIdentity>
+        where TEvent : IAggregateEvent
+        where TIdentity : IIdentity
+    {
+        Task HandleAsync(IDomainEvent<TEvent, TIdentity> e, CancellationToken cancellationToken);
+    }
 }

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -29,7 +29,7 @@ namespace EventFlow.Subscribers
     public interface ISubscribeSynchronousTo<TAggregate, in TIdentity, in TEvent>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
-        where TEvent : IAggregateEvent
+        where TEvent : IAggregateEvent<TAggregate, TIdentity>
     {
         Task HandleAsync(IDomainEvent<TAggregate, TIdentity, TEvent> e, CancellationToken cancellationToken);
     }


### PR DESCRIPTION
There's a mismatch between when a aggregate is a `string`, when its a `IIdentity` and when its a concrete class supplied by the developer.

Notable changes

* `IAggregateRoot` changed to `IAggregateRoot<TIdentity>`
* `ICommand<TAggregate>` changed to `ICommand<TAggregate, TIdentity>`
* `ICommandHandler<TAggregate, TCommand>` changed to `ICommandHandler<TAggregate, TIdentity, TCommand>`
* `IAmReadModelFor<TEvent>` changed to `IAmReadModelFor<TAggregate, TIdentity, TEvent>`
* `IDomainEvent<TEvent>` changed to `IDomainEvent<TAggregate, TIdentity>`

