### PR TITLE
Allow aggregate event Apply methods to be private or protected

### DIFF
--- a/Documentation/Aggregates.md
+++ b/Documentation/Aggregates.md
@@ -60,8 +60,9 @@ public `Apply` methods.
 - Create a method called `Apply` that takes the event as argument. To get the
   method signature right, implement the `IEmit<SomeEvent>` on your aggregate.
   This is the default fallback and you will get an exception if no other
-  strategies are configured
+  strategies are configured. Although you _can_ implement `IEmit<SomeEvent>`,
+  its optional, the `Apply` methods can be `protected` or `private`
 - Register a specific handler for a event using the protected
- `Register<SomeEvent>(e => Handler(e))` from within the constructor
+  `Register<SomeEvent>(e => Handler(e))` from within the constructor
 - Register an event applier using `Register(IEventApplier eventApplier)`,
   which could be a e.g state object

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
  * New: Added a protected method `Register(IEventApplier)` to
    `AggregateRoot<,>` that enables developers to override how events are
    applied. Use this to e.g. implement a state object
+ * New: Allow `AggregateRoot<,>` methods for applying events, i.e.,
+  `Apply(...)`, are now allowed to be `private` and `protected`
  * New: Made `AggregateRoot<,>.Emit(...)` protected and virtual to allow
    overrides that e.g. add a standard set of metadata from the aggregate state.
  * New: Made `AggregateRoot<,>.ApplyEvent(...)` protected and virtual to

--- a/Source/EventFlow.TestHelpers/Aggregates/Test/TestAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Test/TestAggregate.cs
@@ -34,7 +34,7 @@ namespace EventFlow.TestHelpers.Aggregates.Test
         private readonly List<PingId> _pingsReceived = new List<PingId>();
 
         public bool DomainErrorAfterFirstReceived { get; private set; }
-        public IReadOnlyCollection<PingId> PingsReceived { get {return _pingsReceived; } }
+        public IReadOnlyCollection<PingId> PingsReceived { get { return _pingsReceived; } }
 
         public TestAggregate(TestId id) : base(id)
         {

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -83,6 +83,16 @@ namespace EventFlow.Tests.UnitTests.Aggregates
         }
 
         [Test]
+        public void ApplyIsInvoked()
+        {
+            // Act
+            Sut.DomainErrorAfterFirst();
+
+            // Assert
+            Sut.DomainErrorAfterFirstReceived.Should().BeTrue();
+        }
+
+        [Test]
         public void ApplyEventsReadsAggregateSequenceNumber()
         {
             // Arrange

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.EventStores;
@@ -175,7 +176,12 @@ namespace EventFlow.Aggregates
                 aggregateEventType,
                 t =>
                     {
-                        var m = aggregateType.GetMethod("Apply", new []{ t });
+                        var m = aggregateType.GetMethod(
+                            "Apply",
+                            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                            null,
+                            new []{ t },
+                            null);
                         if (m == null)
                         {
                             throw WrongImplementationException.With(


### PR DESCRIPTION
Allow developers to hide the aggregate event Apply methods by making them protected or private.

Fixes #76.