### PR TITLE
Added an AutofacAggregateFactory to EventFlow.Autofac

### DIFF
--- a/EventFlow.sln
+++ b/EventFlow.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.RabbitMQ", "Sourc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.RabbitMQ.Tests", "Source\EventFlow.RabbitMQ.Tests\EventFlow.RabbitMQ.Tests.csproj", "{BC96BEAE-E84E-4C51-B66D-DA1F43EAD54A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.Autofac.Tests", "Source\EventFlow.Autofac.Tests\EventFlow.Autofac.Tests.csproj", "{EDCD8854-6224-4329-87C2-9ADD7D153070}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,10 @@ Global
 		{BC96BEAE-E84E-4C51-B66D-DA1F43EAD54A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC96BEAE-E84E-4C51-B66D-DA1F43EAD54A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC96BEAE-E84E-4C51-B66D-DA1F43EAD54A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDCD8854-6224-4329-87C2-9ADD7D153070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDCD8854-6224-4329-87C2-9ADD7D153070}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDCD8854-6224-4329-87C2-9ADD7D153070}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDCD8854-6224-4329-87C2-9ADD7D153070}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,15 @@
    and register a service that implements `ISubscribeSynchronousToAll`. Services
    that implement this will automatically be added using the
    `AddSubscribers(...)` or `AddDefaults(...)` extension to `EventFlowOptions`
+ * New: `AutofacAggregateFactory` added to enable using `Autofac` as aggregate
+   factory making injecting services into an aggregate root constructor 
+   possible. Use `UseAutofacAggregateFactory(...)` to configure and replace 
+   the default `Activator` based aggregate factory
+ * New: `EventFlowOptions AddAggregateRoots(...)` can be used to register 
+   `IAggregateRoot<>` components thereby eliminating the need to use 
+   `RegisterServices(...)`
+ * New: Added `IServiceRegistration RegisterType(...)` to simplify registering 
+   services by type.   
 
 ### New in 0.10.642 (released 2015-08-17)
 

--- a/Source/EventFlow.Autofac.Tests/EventFlow.Autofac.Tests.csproj
+++ b/Source/EventFlow.Autofac.Tests/EventFlow.Autofac.Tests.csproj
@@ -8,14 +8,14 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EventFlow.Autofac.Tests</RootNamespace>
     <AssemblyName>EventFlow.Autofac.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
@@ -55,14 +57,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise />
-  </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnitTests\Aggregates\AggregateFactoryTests.cs" />
@@ -84,27 +78,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/EventFlow.Autofac.Tests/EventFlow.Autofac.Tests.csproj
+++ b/Source/EventFlow.Autofac.Tests/EventFlow.Autofac.Tests.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EDCD8854-6224-4329-87C2-9ADD7D153070}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EventFlow.Autofac.Tests</RootNamespace>
+    <AssemblyName>EventFlow.Autofac.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.5.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.5.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\Aggregates\AggregateFactoryTests.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\EventFlow.Autofac\EventFlow.Autofac.csproj">
+      <Project>{26f06682-3364-4c22-b9b2-2f2653d0be0d}</Project>
+      <Name>EventFlow.Autofac</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EventFlow.TestHelpers\EventFlow.TestHelpers.csproj">
+      <Project>{571d291c-5e4c-43af-855f-7c4e2f318f4c}</Project>
+      <Name>EventFlow.TestHelpers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EventFlow\EventFlow.csproj">
+      <Project>{11131251-778d-4d2e-bdd1-4844a789bca9}</Project>
+      <Name>EventFlow</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EventFlow.Autofac.Tests/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EventFlow.Autofac.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EventFlow.Autofac.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("edcd8854-6224-4329-87c2-9add7d153070")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/EventFlow.Autofac.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
@@ -1,0 +1,104 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015 Rasmus Mikkelsen, Jaco Coetzee
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Autofac;
+using EventFlow.Aggregates;
+using EventFlow.Autofac.Extensions;
+using EventFlow.Configuration;
+using EventFlow.TestHelpers.Aggregates.Test;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Autofac.Tests.UnitTests.Aggregates
+{
+    [TestFixture]
+    public class AggregateFactoryTests
+    {
+        [Test]
+        public async void AutofacAggregateFactoryResolvesConstructorParameters()
+        {
+            // Arrange
+            var containerBuilder = new ContainerBuilder();
+            using (var resolver = EventFlowOptions.New
+                .UseAutofacContainerBuilder(containerBuilder)
+                .UseAutofacAggregateFactory()
+                .RegisterServices(f => f.RegisterType(typeof(TestAggregate)))
+                .RegisterServices(f => f.RegisterType(typeof(TestAggregateWithResolver)))
+                .RegisterServices(f => f.RegisterType(typeof(TestAggregateWithPinger)))
+                .RegisterServices(f => f.RegisterType(typeof(Pinger)))
+                .CreateResolver(false))
+            {
+                // Arrange
+                var id = TestId.New;
+                var sut = resolver.Resolve<IAggregateFactory>();
+
+                // Act
+                var a = await sut.CreateNewAggregateAsync<TestAggregate, TestId>(id);
+                var ar = await sut.CreateNewAggregateAsync<TestAggregateWithResolver, TestId>(id);
+                var ap = await sut.CreateNewAggregateAsync<TestAggregateWithPinger, TestId>(id);
+
+                // Assert
+                a.Id.Should().Be(id);
+                ar.Resolver.Should().BeAssignableTo<IResolver>();
+                ap.Pinger.Should().BeOfType<Pinger>();
+            }
+        }
+
+        public class Pinger
+        {
+            public void Ping()
+            {
+                // void
+            }
+        }
+
+        public class TestAggregate : AggregateRoot<TestAggregate, TestId>
+        {
+            public TestAggregate(TestId id)
+                : base(id)
+            {
+            }
+        }
+
+        public class TestAggregateWithPinger : AggregateRoot<TestAggregateWithPinger, TestId>
+        {
+            public TestAggregateWithPinger(TestId id, Pinger pinger)
+                : base(id)
+            {
+                Pinger = pinger;
+            }
+
+            public Pinger Pinger { get; }
+        }
+
+        public class TestAggregateWithResolver : AggregateRoot<TestAggregateWithResolver, TestId>
+        {
+            public TestAggregateWithResolver(TestId id, IResolver resolver)
+                : base(id)
+            {
+                Resolver = resolver;
+            }
+
+            public IResolver Resolver { get; }
+        }
+    }
+}

--- a/Source/EventFlow.Autofac.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
@@ -27,6 +27,7 @@ using EventFlow.Configuration;
 using EventFlow.TestHelpers.Aggregates.Test;
 using FluentAssertions;
 using NUnit.Framework;
+using EventFlow.Extensions;
 
 namespace EventFlow.Autofac.Tests.UnitTests.Aggregates
 {
@@ -41,11 +42,9 @@ namespace EventFlow.Autofac.Tests.UnitTests.Aggregates
             using (var resolver = EventFlowOptions.New
                 .UseAutofacContainerBuilder(containerBuilder)
                 .UseAutofacAggregateFactory()
-                .RegisterServices(f => f.RegisterType(typeof(TestAggregate)))
-                .RegisterServices(f => f.RegisterType(typeof(TestAggregateWithResolver)))
-                .RegisterServices(f => f.RegisterType(typeof(TestAggregateWithPinger)))
+                .AddAggregateRoots(typeof(AggregateFactoryTests).Assembly)
                 .RegisterServices(f => f.RegisterType(typeof(Pinger)))
-                .CreateResolver(false))
+                .CreateResolver())
             {
                 // Arrange
                 var id = TestId.New;

--- a/Source/EventFlow.Autofac.Tests/app.config
+++ b/Source/EventFlow.Autofac.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1507.118" newVersion="4.2.1507.118" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/EventFlow.Autofac.Tests/app.config
+++ b/Source/EventFlow.Autofac.Tests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1507.118" newVersion="4.2.1507.118" />
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1507.118" newVersion="4.2.1507.118"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/Source/EventFlow.Autofac.Tests/packages.config
+++ b/Source/EventFlow.Autofac.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="3.5.2" targetFramework="net452" />
+  <package id="FluentAssertions" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+</packages>

--- a/Source/EventFlow.Autofac/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow.Autofac/Aggregates/AggregateFactory.cs
@@ -20,34 +20,30 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
+using EventFlow.Aggregates;
+using EventFlow.Configuration;
+using Autofac;
+using System.Threading.Tasks;
 using EventFlow.Configuration.Registrations;
 
-namespace EventFlow.Configuration
+namespace EventFlow.Autofac.Aggregates
 {
-    public interface IServiceRegistration
+    public class AggregateFactory : IAggregateFactory
     {
-        void Register<TService, TImplementation>(Lifetime lifetime = Lifetime.AlwaysUnique)
-            where TImplementation : class, TService
-            where TService : class;
+        private AutofacResolver _resolver;
 
-        void Register<TService>(Func<IResolverContext, TService> factory, Lifetime lifetime = Lifetime.AlwaysUnique)
-            where TService : class;
+        public AggregateFactory(IResolver resolver)
+        {
+            _resolver = (AutofacResolver)resolver;
+        }
 
-        void Register(Type serviceType, Type implementationType, Lifetime lifetime = Lifetime.AlwaysUnique);
-
-        void RegisterType(Type serviceType, Lifetime lifetime = Lifetime.AlwaysUnique);
-
-        void RegisterGeneric(Type serviceType, Type implementationType, Lifetime lifetime = Lifetime.AlwaysUnique);
-
-        void Decorate<TService>(Func<IResolverContext, TService, TService> factory);
-
-        bool HasRegistrationFor<TService>()
-            where TService : class;
-
-        IEnumerable<Type> GetRegisteredServices();
-            
-        IRootResolver CreateResolver(bool validateRegistrations);
+        public Task<TAggregate> CreateNewAggregateAsync<TAggregate, TIdentity>(TIdentity id)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+        {
+            var aggregate = _resolver.Resolve<TAggregate>(new TypedParameter(typeof(TIdentity), id));
+            return Task.FromResult(aggregate);
+        }
     }
 }
+

--- a/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
+++ b/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Aggregates\AggregateFactory.cs" />
     <Compile Include="Extensions\EventFlowOptionsAutofacExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -76,6 +77,7 @@
       <Name>EventFlow</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
+++ b/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
@@ -22,6 +22,7 @@
 
 using System;
 using Autofac;
+using EventFlow.Aggregates;
 using EventFlow.Configuration.Registrations;
 
 namespace EventFlow.Autofac.Extensions
@@ -34,6 +35,14 @@ namespace EventFlow.Autofac.Extensions
         {
             return eventFlowOptions
                 .UseServiceRegistration(new AutofacServiceRegistration(containerBuilder));
+        }
+
+        public static EventFlowOptions UseAutofacAggregateFactory(
+            this EventFlowOptions eventFlowOptions)
+        {
+            return eventFlowOptions
+                .RegisterServices(f => f.Register<IAggregateFactory, Aggregates.AggregateFactory>(
+                    Lifetime.Singleton));
         }
 
         public static IContainer CreateContainer(

--- a/Source/EventFlow.Tests/EventFlow.Tests.csproj
+++ b/Source/EventFlow.Tests/EventFlow.Tests.csproj
@@ -115,6 +115,9 @@
   <ItemGroup>
     <Folder Include="TestData\FilesEventStore\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/EventFlow/Configuration/Registrations/AutofacResolver.cs
+++ b/Source/EventFlow/Configuration/Registrations/AutofacResolver.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Autofac;
+using Autofac.Core;
 
 namespace EventFlow.Configuration.Registrations
 {
@@ -42,9 +43,19 @@ namespace EventFlow.Configuration.Registrations
             return _componentContext.Resolve<T>();
         }
 
+        public T Resolve<T>(params Parameter[] parameters)
+        {
+            return _componentContext.Resolve<T>(parameters);
+        }
+
         public object Resolve(Type serviceType)
         {
             return _componentContext.Resolve(serviceType);
+        }
+
+        public object Resolve(Type serviceType, params Parameter[] parameters)
+        {
+            return _componentContext.Resolve(serviceType, parameters);
         }
 
         public IEnumerable<object> ResolveAll(Type serviceType)

--- a/Source/EventFlow/Configuration/Registrations/AutofacServiceRegistration.cs
+++ b/Source/EventFlow/Configuration/Registrations/AutofacServiceRegistration.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Autofac;
 using Autofac.Core;
+using EventFlow.Aggregates;
 
 namespace EventFlow.Configuration.Registrations
 {
@@ -129,6 +130,7 @@ namespace EventFlow.Configuration.Registrations
                 .SelectMany(x => x.Services)
                 .OfType<TypedService>()
                 .Where(x => !x.ServiceType.Name.StartsWith("Autofac"))
+                .Where(x => !x.ServiceType.IsClosedTypeOf(typeof(IAggregateRoot<>)))
                 .ToList();
             var exceptions = new List<Exception>();
             foreach (var typedService in services)

--- a/Source/EventFlow/Configuration/Registrations/AutofacServiceRegistration.cs
+++ b/Source/EventFlow/Configuration/Registrations/AutofacServiceRegistration.cs
@@ -58,6 +58,11 @@ namespace EventFlow.Configuration.Registrations
             _registrations.Add(new AutofacRegistration(serviceType, implementationType, lifetime));
         }
 
+        public void RegisterType(Type serviceType, Lifetime lifetime = Lifetime.AlwaysUnique)
+        {
+            _registrations.Add(new AutofacRegistration(serviceType, serviceType, lifetime));
+        }
+
         public void RegisterGeneric(Type serviceType, Type implementationType, Lifetime lifetime = Lifetime.AlwaysUnique)
         {
             _registrations.Add(new AutofacGeneticRegistration(serviceType, implementationType, lifetime));

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -20,7 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -115,6 +115,7 @@
     <Compile Include="Extensions\DateTimeOffsetExtensions.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
     <Compile Include="Extensions\DisposableExtensions.cs" />
+    <Compile Include="Extensions\EventFlowOptionsAggregatesExtensions.cs" />
     <Compile Include="Extensions\EventFlowOptionsCommandExtensions.cs" />
     <Compile Include="Extensions\EventFlowOptionsDefaultExtensions.cs" />
     <Compile Include="Extensions\EventFlowOptionsEventsExtensions.cs" />

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -20,7 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
@@ -1,0 +1,67 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015 Rasmus Mikkelsen
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using EventFlow.Aggregates;
+using Autofac;
+
+namespace EventFlow.Extensions
+{
+    public static class EventFlowOptionsAggregatesExtensions
+    {
+        public static EventFlowOptions AddAggregateRoots(
+            this EventFlowOptions eventFlowOptions,
+            Assembly fromAssembly)
+        {
+            var aggregateRootTypes = fromAssembly
+                .GetTypes()
+                .Where(t => !t.IsAbstract && t.IsClosedTypeOf(typeof(IAggregateRoot<>)));
+            eventFlowOptions.AddAggregateRoots(aggregateRootTypes);
+            return eventFlowOptions;
+        }
+
+        public static EventFlowOptions AddAggregateRoots(
+            this EventFlowOptions eventFlowOptions,
+            params Type[] aggregateRootTypes)
+        {
+            foreach (var t in aggregateRootTypes)
+            {
+                eventFlowOptions.RegisterServices(sr => sr.RegisterType(t));
+            }
+            return eventFlowOptions;
+        }
+
+        public static EventFlowOptions AddAggregateRoots(
+            this EventFlowOptions eventFlowOptions,
+            IEnumerable<Type> aggregateRootTypes)
+        {
+            foreach (var t in aggregateRootTypes)
+            {
+                eventFlowOptions.RegisterServices(sr => sr.RegisterType(t));
+            }
+            return eventFlowOptions;
+        }
+    }
+}


### PR DESCRIPTION
Added:
-  RegisterType() method to IServiceRegistration to simplify registering by type
- support for parameters in AutofacResolver.Resolve methods using overloads
- UseAutofacAggregateFactory() to EventFlowOptionsAutofacExtensions