### PR TITLE
Prevent abstract AggregateRoot<,> implementations from being register…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### New in 0.13 (not released yet)
 
- * _Nothing yet_
+ * Fixed: `EventFlowOptions.AddAggregateRoots(...)` now prevents abstract classes 
+   from being registered when passing `IEnumerable<Type>`.   
 
 ### New in 0.12.891 (released 2015-09-04)
 

--- a/Source/EventFlow.Tests/EventFlow.Tests.csproj
+++ b/Source/EventFlow.Tests/EventFlow.Tests.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventFlowTests.cs" />
     <Compile Include="IntegrationTests\BackwardCompatibilityTests.cs" />
     <Compile Include="IntegrationTests\ConfigurationTests.cs" />
     <Compile Include="IntegrationTests\DomainTests.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="UnitTests\Commands\DistinctCommandTests.cs" />
     <Compile Include="UnitTests\Core\CircularBufferTests.cs" />
     <Compile Include="UnitTests\Core\IdentityTests.cs" />
+    <Compile Include="UnitTests\Extensions\AggregatesExtensionsTests.cs" />
     <Compile Include="UnitTests\Extensions\StringExtensionsTests.cs" />
     <Compile Include="UnitTests\Queries\QueryProcessorTests.cs" />
     <Compile Include="UnitTests\ReadStores\ReadModelDomainEventApplierTests.cs" />

--- a/Source/EventFlow.Tests/EventFlowTests.cs
+++ b/Source/EventFlow.Tests/EventFlowTests.cs
@@ -1,0 +1,31 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015 Rasmus Mikkelsen
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Reflection;
+
+namespace EventFlow.Tests
+{
+    public static class EventFlowTests
+    {
+        public static Assembly Assembly { get; } = typeof(EventFlowTests).Assembly;
+    }
+}

--- a/Source/EventFlow.Tests/UnitTests/Extensions/AggregatesExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/AggregatesExtensionsTests.cs
@@ -1,0 +1,132 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015 Rasmus Mikkelsen
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using EventFlow.Aggregates;
+using EventFlow.Extensions;
+using EventFlow.TestHelpers.Aggregates.Test;
+using EventFlow.TestHelpers.Aggregates.Test.Events;
+using FluentAssertions;
+using NUnit.Framework;
+using EventFlow.Configuration.Registrations;
+using EventFlow.TestHelpers;
+using System.Collections.Generic;
+
+namespace EventFlow.Tests.UnitTests.Extensions
+{
+    public class AggregatesExtensionsTests
+    {
+        [Test]
+        public void AbstractAggregateRootImplementationIsNotSelected()
+        {
+            // arrange
+            var registry = new AutofacServiceRegistration();
+            var sut = EventFlowOptions.New
+                .UseServiceRegistration(registry);
+
+            // act
+            sut.AddAggregateRoots(EventFlowTests.Assembly);
+
+            // assert
+            registry.HasRegistrationFor<AbstractTestAggregate>().Should().Be(false);
+        }
+
+        [Test]
+        public void ClosedIAggregateRootImplementationIsSelected()
+        {
+            // arrange
+            var registry = new AutofacServiceRegistration();
+            var sut = EventFlowOptions.New
+                .UseServiceRegistration(registry);
+
+            // act
+            sut.AddAggregateRoots(EventFlowTestHelpers.Assembly);
+
+            // assert
+            registry.HasRegistrationFor<TestAggregate>().Should().Be(true);
+        }
+
+        [Test]
+        public void AbstractAggregateRootImplementationIsRejected()
+        {
+            // arrange
+            var registry = new AutofacServiceRegistration();
+            var sut = EventFlowOptions.New
+                .UseServiceRegistration(registry);
+
+            // act
+            Action act = () => sut.AddAggregateRoots(new List<Type> { typeof(AbstractTestAggregate) } );
+
+            // assert
+            act.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void NonIAggregateRootImplementationIsRejected()
+        {
+            // arrange
+            var registry = new AutofacServiceRegistration();
+            var sut = EventFlowOptions.New
+                .UseServiceRegistration(registry);
+
+            // act
+            Action act = () => sut.AddAggregateRoots(new List<Type> { typeof(TestId) });
+
+            // assert
+            act.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void ClosedIAggregateRootImplementationIsAccepted()
+        {
+            // arrange
+            var registry = new AutofacServiceRegistration();
+            var sut = EventFlowOptions.New
+                .UseServiceRegistration(registry);
+
+            // act
+            Action act = () => sut.AddAggregateRoots(new List<Type> { typeof(LocalTestAggregate) });
+
+            // assert
+            act.ShouldNotThrow<ArgumentException>();
+        }
+    }
+
+    public abstract class AbstractTestAggregate : AggregateRoot<TestAggregate, TestId>,
+        IEmit<DomainErrorAfterFirstEvent>
+    {
+        public AbstractTestAggregate(TestId id) : base(id)
+        {
+        }
+
+        public void Apply(DomainErrorAfterFirstEvent aggregateEvent)
+        {
+        }
+    }
+
+    public class LocalTestAggregate : AbstractTestAggregate
+    {
+        public LocalTestAggregate(TestId id) : base(id)
+        {
+        }
+    }
+}

--- a/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
@@ -44,7 +44,8 @@ namespace EventFlow.Extensions
         {
             var aggregateRootTypes = fromAssembly
                 .GetTypes()
-                .Where(t => !t.IsAbstract && t.IsClosedTypeOf(typeof(IAggregateRoot<>)));
+                .Where(t => !t.IsAbstract)
+                .Where(t => t.IsClosedTypeOf(typeof(IAggregateRoot<>)));
             eventFlowOptions.AddAggregateRoots(aggregateRootTypes);
             return eventFlowOptions;
         }
@@ -61,15 +62,13 @@ namespace EventFlow.Extensions
             this EventFlowOptions eventFlowOptions,
             IEnumerable<Type> aggregateRootTypes)
         {
-            var invalidateTypes = aggregateRootTypes
-                .Where(t => !t.IsClosedTypeOf(typeof(IAggregateRoot<>)))
+            var invalidTypes = aggregateRootTypes
+                .Where(t => t.IsAbstract || !t.IsClosedTypeOf(typeof(IAggregateRoot<>)))
                 .ToList();
-            if (invalidateTypes.Any())
+            if (invalidTypes.Any())
             {
-                var names = string.Join(", ", invalidateTypes.Select(t => t.Name));
-                throw new ArgumentException(string.Format(
-                    "Type(s) '{0}' do not implement IAggregateRoot<TIdentity>",
-                    names));
+                var names = string.Join(", ", invalidTypes.Select(t => t.Name));
+                throw new ArgumentException($"Type(s) '{names}' do not implement IAggregateRoot<TIdentity>");
             }
 
             foreach (var t in aggregateRootTypes)


### PR DESCRIPTION
…ed as services

- missing check for abstract registrations added
- AggregateExtensionsTests added to check behavior
- assembly helper added to EventFlow.Tests

was #113