### PR TITLE
ICommand<> defined on Command<,> in EventFlow.Commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### New in 0.16 (not released yet)
 
-* _Nothing yet_
+* Fixed: Added missing `ICommand<,>` interface to abstract `Command<,>` class in 
+  `EventFlow.Commands`.
 
 ### New in 0.15.1057 (released 2015-09-24)
 

--- a/Source/EventFlow/Commands/Command.cs
+++ b/Source/EventFlow/Commands/Command.cs
@@ -56,7 +56,8 @@ namespace EventFlow.Commands
         }
     }
 
-    public abstract class Command<TAggregate, TIdentity> : Command<TAggregate, TIdentity, ISourceId>
+    public abstract class Command<TAggregate, TIdentity> : Command<TAggregate, TIdentity, ISourceId>,
+        ICommand<TAggregate, TIdentity>
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
     {


### PR DESCRIPTION
- caused a break in project dependant on implicit ICommand<,> cast
- now matches Command<,,> with interface ICommand<,,>