### PR TITLE
Minor fix for DomainError.With

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
   `IJobsDefinitonService` now longer throw an exception if an existing
   event is loaded, i.e., multiple calls to `AddEvents(...)`, `AddCommand(...)`
   and `AddJobs(...)` no longer throws an exception
+* Fixed: `DomainError.With(...)` no longer executes `string.format` if only
+  one argument is parsed
 
 ### New in 0.18.1181 (released 2015-10-07)
 

--- a/Source/EventFlow/Exceptions/DomainError.cs
+++ b/Source/EventFlow/Exceptions/DomainError.cs
@@ -28,21 +28,31 @@ namespace EventFlow.Exceptions
     public class DomainError : Exception
     {
         protected DomainError(string message)
-            : base(message) { }
+            : base(message)
+        {
+        }
 
         protected DomainError(string message, Exception innerException)
-            : base(message, innerException) { }
+            : base(message, innerException)
+        {
+        }
 
         [StringFormatMethod("format")]
         public static DomainError With(string format, params object[] args)
         {
-            return new DomainError(string.Format(format, args));
+            var message = args.Length <= 0
+                ? format
+                : string.Format(format, args);
+            return new DomainError(message);
         }
 
         [StringFormatMethod("format")]
         public static DomainError With(Exception innerException, string format, params object[] args)
         {
-            return new DomainError(string.Format(format, args), innerException);
+            var message = args.Length <= 0
+                ? format
+                : string.Format(format, args);
+            return new DomainError(message, innerException);
         }
     }
 }


### PR DESCRIPTION
`DomainError.With(...)` no longer executes `string.format` if only one argument is parsed