### PR TITLE
Remove references to aggregates from event persistence

### DIFF
--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -129,6 +129,7 @@
     <Compile Include="EventStores\AllCommittedEventsPage.cs" />
     <Compile Include="EventStores\AllEventsPage.cs" />
     <Compile Include="Core\VersionedTypes\VersionedTypeDefinitionService.cs" />
+    <Compile Include="EventStores\CommittedDomainEvent.cs" />
     <Compile Include="EventStores\EventDefinition.cs" />
     <Compile Include="EventStores\EventVersionAttribute.cs" />
     <Compile Include="EventStores\Files\FilesEventLocator.cs" />

--- a/Source/EventFlow/EventStores/CommittedDomainEvent.cs
+++ b/Source/EventFlow/EventStores/CommittedDomainEvent.cs
@@ -1,0 +1,44 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015 Rasmus Mikkelsen
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.EventStores
+{
+    public class CommittedDomainEvent : ICommittedDomainEvent
+    {
+        public CommittedDomainEvent(
+            string aggregateId,
+            string data,
+            string metadata,
+            int aggregateSequenceNumber)
+        {
+            AggregateId = aggregateId;
+            Data = data;
+            Metadata = metadata;
+            AggregateSequenceNumber = aggregateSequenceNumber;
+        }
+
+        public string AggregateId { get; }
+        public string Data { get; }
+        public string Metadata { get; }
+        public int AggregateSequenceNumber { get; }
+    }
+}


### PR DESCRIPTION
In preparation of separating the event sourcing parts of EventFlow, the event persistence layers needs to have all references to aggregates removed. The underlying data models of e.g. the MSSQL event store will still have columns that have these names to still be backwards compatible. 