### PR TITLE
Better performance for invocation of reflected methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,11 @@
 ### New in 0.23 (not released yet)
 
+* Fixed: Instead of using `MethodInfo.Invoke` to call methods on reflected
+  types, e.g. when a command is published, EventFlow now compiles an expression
+  tree instead. This has a slight initial overhead, but provides a significant
+  performance improvement for subsequent calls
 * Fixed: EventFlow no longer ignores columns named `Id` in MSSQL read models.
-  If you were dependent on this, use the `MsSqlReadModelIgnoreColumn` attribute 
+  If you were dependent on this, use the `MsSqlReadModelIgnoreColumn` attribute
 * Fixed: EventFlow now correctly throws an `ArgumentException` if EventFlow has
   been incorrectly configure with known versioned types, e.g. an event
   is emitted that hasn't been added during EventFlow initialization. EventFlow

--- a/Source/EventFlow.Tests/EventFlow.Tests.csproj
+++ b/Source/EventFlow.Tests/EventFlow.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="UnitTests\Configuration\ModuleRegistrationTests.cs" />
     <Compile Include="UnitTests\Core\CircularBufferTests.cs" />
     <Compile Include="UnitTests\Core\IdentityTests.cs" />
+    <Compile Include="UnitTests\Core\ReflectionHelperTests.cs" />
     <Compile Include="UnitTests\Extensions\AggregatesExtensionsTests.cs" />
     <Compile Include="UnitTests\Extensions\StringExtensionsTests.cs" />
     <Compile Include="UnitTests\Extensions\TypeExtensionsTests.cs" />

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -32,10 +32,10 @@ namespace EventFlow.Tests.UnitTests.Core
     public class ReflectionHelperTests
     {
         [Test]
-        public void CallFactory()
+        public void CompileMethodInvocation()
         {
             // Act
-            var caller = ReflectionHelper.CallFactory<Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
+            var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
             var result = caller(new Calculator(), 1, 2);
 
             // Assert

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -1,0 +1,53 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015 Rasmus Mikkelsen
+// Copyright (c) 2015 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using EventFlow.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.UnitTests.Core
+{
+    public class ReflectionHelperTests
+    {
+        [Test]
+        public void CallFactory()
+        {
+            // Act
+            var caller = ReflectionHelper.CallFactory<int, Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
+            var result = caller(new Calculator(), 1, 2);
+
+            // Assert
+            result.Should().Be(3);
+        }
+
+        public class Calculator
+        {
+            public int Add(int a, int b)
+            {
+                return a + b;
+            }
+        }
+    }
+}

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -35,7 +35,7 @@ namespace EventFlow.Tests.UnitTests.Core
         public void CallFactory()
         {
             // Act
-            var caller = ReflectionHelper.CallFactory<int, Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
+            var caller = ReflectionHelper.CallFactory<Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
             var result = caller(new Calculator(), 1, 2);
 
             // Assert

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -58,6 +58,22 @@ namespace EventFlow.Tests.UnitTests.Core
             c.I.Should().Be(3);
         }
 
+        [Test]
+        public void CompileMethodInvocation_CanDoBothUpcastAndPass()
+        {
+            // Arrange
+            var a = (INumber)new Number { I = 1 };
+            const int b = 2;
+
+            // Act
+            var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, INumber, int, INumber>>(typeof(Calculator), "Add", typeof(Number), typeof(int));
+            var result = caller(new Calculator(), a, b);
+
+            // Assert
+            var c = (Number)result;
+            c.I.Should().Be(3);
+        }
+
         public interface INumber { }
 
         public class Number : INumber
@@ -75,6 +91,11 @@ namespace EventFlow.Tests.UnitTests.Core
             public Number Add(Number a, Number b)
             {
                 return new Number {I = Add(a.I, b.I)};
+            }
+
+            public Number Add(Number a, int b)
+            {
+                return new Number { I = Add(a.I, b) };
             }
         }
     }

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -35,11 +35,34 @@ namespace EventFlow.Tests.UnitTests.Core
         public void CompileMethodInvocation()
         {
             // Act
-            var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, int, int, int>>(typeof (Calculator), "Add");
+            var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, int, int, int>>(typeof (Calculator), "Add", typeof(int), typeof(int));
             var result = caller(new Calculator(), 1, 2);
 
             // Assert
             result.Should().Be(3);
+        }
+
+        [Test]
+        public void CompileMethodInvocation_CanUpcast()
+        {
+            // Arrange
+            var a = (INumber) new Number {I = 1};
+            var b = (INumber) new Number {I = 2};
+
+            // Act
+            var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, INumber, INumber, INumber>>(typeof(Calculator), "Add", typeof(Number), typeof(Number));
+            var result = caller(new Calculator(), a, b);
+
+            // Assert
+            var c = (Number) result;
+            c.I.Should().Be(3);
+        }
+
+        public interface INumber { }
+
+        public class Number : INumber
+        {
+            public int I { get; set; }
         }
 
         public class Calculator
@@ -47,6 +70,11 @@ namespace EventFlow.Tests.UnitTests.Core
             public int Add(int a, int b)
             {
                 return a + b;
+            }
+
+            public Number Add(Number a, Number b)
+            {
+                return new Number {I = Add(a.I, b.I)};
             }
         }
     }

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -20,7 +20,8 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
+//
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -53,6 +54,7 @@ namespace EventFlow.Aggregates
         static AggregateRoot()
         {
             var aggregateEventType = typeof(IAggregateEvent<TAggregate, TIdentity>);
+            var aggregateType = typeof(TAggregate);
 
             ApplyMethods = typeof(TAggregate)
                 .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
@@ -66,7 +68,7 @@ namespace EventFlow.Aggregates
                     })
                 .ToDictionary(
                     mi => mi.GetParameters()[0].ParameterType,
-                    mi => (Action<TAggregate, IAggregateEvent>)((a, e) => mi.Invoke(a, new object[] { e })));
+                    mi => ReflectionHelper.CompileMethodInvocation<Action<TAggregate, IAggregateEvent>>(aggregateType, "Apply", mi.GetParameters()[0].ParameterType));
         }
 
         protected AggregateRoot(TIdentity id)

--- a/Source/EventFlow/Aggregates/AggregateState.cs
+++ b/Source/EventFlow/Aggregates/AggregateState.cs
@@ -40,8 +40,9 @@ namespace EventFlow.Aggregates
         static AggregateState()
         {
             var aggregateEventType = typeof (IAggregateEvent<TAggregate, TIdentity>);
+            var eventApplier = typeof (TEventApplier);
 
-            ApplyMethods = typeof (TEventApplier)
+            ApplyMethods = eventApplier
                 .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(mi =>
                     {
@@ -53,7 +54,7 @@ namespace EventFlow.Aggregates
                     })
                 .ToDictionary(
                     mi => mi.GetParameters()[0].ParameterType,
-                    mi => (Action<TEventApplier, IAggregateEvent<TAggregate, TIdentity>>) ((ea, e) => mi.Invoke(ea, new []{ e } )));
+                    mi => ReflectionHelper.CompileMethodInvocation<Action<TEventApplier, IAggregateEvent<TAggregate, TIdentity>>>(eventApplier, "Apply", mi.GetParameters()[0].ParameterType));
         }
 
         protected AggregateState()

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -211,7 +211,7 @@ namespace EventFlow
                             {
                                 AggregateType = commandTypes[0],
                                 CommandHandlerType = commandHandlerType,
-                                Invoker = ((h, a, command, c) => (Task)invoker.Invoke(h, new object[] { a, command, c }))
+                                Invoker = ReflectionHelper.CallFactory<Func<ICommandHandler, IAggregateRoot, ICommand, CancellationToken, Task>>(commandHandlerType, "ExecuteAsync") // ((h, a, command, c) => (Task)invoker.Invoke(h, new object[] { a, command, c }))
                             };
                     });
         }

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -205,11 +205,13 @@ namespace EventFlow
                         var commandHandlerType = typeof(ICommandHandler<,,,>)
                             .MakeGenericType(commandTypes[0], commandTypes[1], commandTypes[2], commandType);
 
+                        var invokeExecuteAsync = ReflectionHelper.CompileMethodInvocation<Func<ICommandHandler, IAggregateRoot, ICommand, CancellationToken, Task>>(commandHandlerType, "ExecuteAsync");
+
                         return new CommandExecutionDetails
                             {
                                 AggregateType = commandTypes[0],
                                 CommandHandlerType = commandHandlerType,
-                                Invoker = ReflectionHelper.CompileMethodInvocation<Func<ICommandHandler, IAggregateRoot, ICommand, CancellationToken, Task>>(commandHandlerType, "ExecuteAsync")
+                                Invoker = invokeExecuteAsync
                             };
                     });
         }

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -205,13 +205,11 @@ namespace EventFlow
                         var commandHandlerType = typeof(ICommandHandler<,,,>)
                             .MakeGenericType(commandTypes[0], commandTypes[1], commandTypes[2], commandType);
 
-                        var invoker = commandHandlerType.GetMethod("ExecuteAsync");
-
                         return new CommandExecutionDetails
                             {
                                 AggregateType = commandTypes[0],
                                 CommandHandlerType = commandHandlerType,
-                                Invoker = ReflectionHelper.CallFactory<Func<ICommandHandler, IAggregateRoot, ICommand, CancellationToken, Task>>(commandHandlerType, "ExecuteAsync") // ((h, a, command, c) => (Task)invoker.Invoke(h, new object[] { a, command, c }))
+                                Invoker = ReflectionHelper.CompileMethodInvocation<Func<ICommandHandler, IAggregateRoot, ICommand, CancellationToken, Task>>(commandHandlerType, "ExecuteAsync")
                             };
                     });
         }

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -106,7 +106,7 @@ namespace EventFlow.Core
                 {
                     var sourceParameter = Expression.Parameter(a.Source);
                     var destinationVariable = Expression.Variable(a.Destination);
-                    var assignToDestination = Expression.Assign(destinationVariable, Expression.ConvertChecked(sourceParameter, a.Destination));
+                    var assignToDestination = Expression.Assign(destinationVariable, Expression.Convert(sourceParameter, a.Destination));
 
                     lambdaArgument.Add(sourceParameter);
                     callArguments.Add(destinationVariable);

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -45,11 +45,11 @@ namespace EventFlow.Core
             return codeBase;
         }
 
-        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName)
+        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName, Type[] methodSignature = null)
         {
-            var methodInfo = type
-                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
-                .SingleOrDefault(m => m.Name == methodName);
+            var methodInfo = methodSignature == null
+                ? type.GetMethods(BindingFlags.Instance | BindingFlags.Public).SingleOrDefault(m => m.Name == methodName)
+                : type.GetMethod(methodName, methodSignature);
 
             if (methodInfo == null)
             {
@@ -57,8 +57,8 @@ namespace EventFlow.Core
             }
 
             var genericArguments = typeof (TResult).GetGenericArguments();
-            var funcArgumentList = genericArguments.Skip(1).Take(genericArguments.Length - 2).ToList();
             var methodArgumentList = methodInfo.GetParameters().Select(p => p.ParameterType).ToList();
+            var funcArgumentList = genericArguments.Skip(1).Take(methodArgumentList.Count).ToList();
 
             if (funcArgumentList.Count != methodArgumentList.Count)
             {

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -45,9 +45,9 @@ namespace EventFlow.Core
             return codeBase;
         }
 
-        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName, Type[] methodSignature = null)
+        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName, params Type[] methodSignature)
         {
-            var methodInfo = methodSignature == null
+            var methodInfo = methodSignature == null || !methodSignature.Any()
                 ? type.GetMethods(BindingFlags.Instance | BindingFlags.Public).SingleOrDefault(m => m.Name == methodName)
                 : type.GetMethod(methodName, methodSignature);
 

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -65,14 +65,12 @@ namespace EventFlow.Core
                 throw new ArgumentException("Incorrect number of arguments");
             }
 
-            var varCnt = 1;
-
-            var instanceArgument = Expression.Parameter(genericArguments[0], $"arg{varCnt}"); varCnt++;
+            var instanceArgument = Expression.Parameter(genericArguments[0]);;
             var lambdaArgument = new List<ParameterExpression>
                 {
                     instanceArgument,
                 };
-            var instanceVariable = Expression.Variable(type, $"var{varCnt}"); varCnt++;
+            var instanceVariable = Expression.Variable(type);
             var blockVariables = new List<ParameterExpression>
                 {
                         instanceVariable,
@@ -84,8 +82,8 @@ namespace EventFlow.Core
             var callArguments = new List<ParameterExpression>();
             foreach (var a in funcArgumentList.Zip(methodArgumentList, (s, d) => new {Source = s, Destination = d}))
             {
-                var sourceParameter = Expression.Parameter(a.Source, $"arg{varCnt}"); varCnt++;
-                var destinationVariable = Expression.Variable(a.Destination, $"var{varCnt}"); varCnt++;
+                var sourceParameter = Expression.Parameter(a.Source);
+                var destinationVariable = Expression.Variable(a.Destination);
                 var assignToDestination = Expression.Assign(destinationVariable, Expression.ConvertChecked(sourceParameter, a.Destination));
 
                 lambdaArgument.Add(sourceParameter);

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -96,14 +96,23 @@ namespace EventFlow.Core
 
             foreach (var a in argumentPairs)
             {
-                var sourceParameter = Expression.Parameter(a.Source);
-                var destinationVariable = Expression.Variable(a.Destination);
-                var assignToDestination = Expression.Assign(destinationVariable, Expression.ConvertChecked(sourceParameter, a.Destination));
+                if (a.Source == a.Destination)
+                {
+                    var sourceParameter = Expression.Parameter(a.Source);
+                    lambdaArgument.Add(sourceParameter);
+                    callArguments.Add(sourceParameter);
+                }
+                else
+                {
+                    var sourceParameter = Expression.Parameter(a.Source);
+                    var destinationVariable = Expression.Variable(a.Destination);
+                    var assignToDestination = Expression.Assign(destinationVariable, Expression.ConvertChecked(sourceParameter, a.Destination));
 
-                lambdaArgument.Add(sourceParameter);
-                callArguments.Add(destinationVariable);
-                blockVariables.Add(destinationVariable);
-                blockExpressions.Add(assignToDestination);
+                    lambdaArgument.Add(sourceParameter);
+                    callArguments.Add(destinationVariable);
+                    blockVariables.Add(destinationVariable);
+                    blockExpressions.Add(assignToDestination);
+                }
             }
 
             var callExpression = Expression.Call(instanceVariable, methodInfo, callArguments);

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -45,7 +45,7 @@ namespace EventFlow.Core
             return codeBase;
         }
 
-        public static TResult CallFactory<TResult>(Type type, string methodName)
+        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName)
         {
             var methodInfo = type
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public)

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -21,8 +21,8 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
+
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -130,10 +130,12 @@ namespace EventFlow.EventStores
 
                         var arguments = aggregateRootInterface.GetGenericArguments();
                         var eventUpgraderType = typeof(IEventUpgrader<,>).MakeGenericType(t, arguments[0]);
-                        var methodInfo = eventUpgraderType.GetMethod("Upgrade");
+
+                        var invokeUpgrade = ReflectionHelper.CompileMethodInvocation<Func<object, IDomainEvent, IEnumerable<IDomainEvent>>>(eventUpgraderType, "Upgrade");
+
                         return new EventUpgraderCacheItem(
                             eventUpgraderType,
-                            (o, e) => ((IEnumerable)methodInfo.Invoke(o, new object[] { e })).Cast<IDomainEvent>());
+                            invokeUpgrade);
                     });
         }
     }

--- a/Source/EventFlow/Queries/IQuery.cs
+++ b/Source/EventFlow/Queries/IQuery.cs
@@ -20,10 +20,15 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
+//
+
 namespace EventFlow.Queries
 {
-    public interface IQuery<TResult>
+    public interface IQuery
+    {
+    }
+
+    public interface IQuery<TResult> : IQuery
     {
     }
 }

--- a/Source/EventFlow/Queries/IQueryHandler.cs
+++ b/Source/EventFlow/Queries/IQueryHandler.cs
@@ -26,7 +26,11 @@ using System.Threading.Tasks;
 
 namespace EventFlow.Queries
 {
-    public interface IQueryHandler<in TQuery, TResult>
+    public interface IQueryHandler
+    {
+    }
+
+    public interface IQueryHandler<in TQuery, TResult> : IQueryHandler
         where TQuery : IQuery<TResult>
     {
         Task<TResult> ExecuteQueryAsync(TQuery query, CancellationToken cancellationToken);

--- a/Source/EventFlow/Queries/QueryProcessor.cs
+++ b/Source/EventFlow/Queries/QueryProcessor.cs
@@ -84,12 +84,15 @@ namespace EventFlow.Queries
                 .GetInterfaces()
                 .Single(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof (IQuery<>));
             var queryHandlerType = typeof(IQueryHandler<,>).MakeGenericType(queryType, queryInterfaceType.GetGenericArguments()[0]);
-            var methodInfo = queryHandlerType.GetMethod("ExecuteQueryAsync");
+            var invokeExecuteQueryAsync = ReflectionHelper.CompileMethodInvocation<Func<object, object, CancellationToken, object>>(
+                queryHandlerType,
+                "ExecuteQueryAsync",
+                queryType, typeof(CancellationToken));
             return new CacheItem
                 {
                     QueryHandlerType = queryHandlerType,
-                    HandlerFunc = (h, q, c) => methodInfo.Invoke(h, new object[]{q, c})
-                };
+                    HandlerFunc = invokeExecuteQueryAsync
+            };
         }
     }
 }


### PR DESCRIPTION
It seems like this new code is about 36 times faster then the current using `MethodInfo` directly.

Here's the output
```
Timing Compiled
It took 0,112
Timing MethodInfo
It took 3,592
```

Here's the program

```csharp
public static class Program
{
  public class Calculator
  {
      public int Add(int a, int b)
      {
          return a + b;
      }
  }

  const int Count = 5000000;
  public static int Main(string[] args)
  {
      Time(Compiled, "Compiled");
      Time(MethodInfo, "MethodInfo");

      return 0;
  }

  private static void Time(Func<Action> action, string label)
  {
      Console.WriteLine($"Timing {label}");
      var timedaction = action();
      var stopwatch = Stopwatch.StartNew();
      timedaction();
      stopwatch.Stop();
      Console.WriteLine($"It took {stopwatch.Elapsed.TotalSeconds:0.000}");
  }

  private static Action Compiled()
  {
      var caller = ReflectionHelper.CompileMethodInvocation<Func<Calculator, int, int, int>>(typeof(Calculator), "Add");
      var calculator = new Calculator();
      return () =>
      {
          for (var i = 0; i < Count; i++)
          {
              caller(calculator, 1, 2);
          }
      };
  }

  private static Action MethodInfo()
  {
      var methodInfo = typeof (Calculator).GetMethod("Add");
      Func<Calculator, int, int, int> caller = (c, i1, i2) => (int) methodInfo.Invoke(c, new object[] {i1, i2});
      var calculator = new Calculator();
      return () =>
      {
          for (var i = 0; i < Count; i++)
          {
              caller(calculator, 1, 2);
          }
      };
  }
}
```