### PR TITLE
Fix deadlock problem in AsyncHelper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,22 @@
-### New in 0.24 (not released yet)
+### New in 0.25 (not released yet)
+
+* Fixed: Deadlock in `AsyncHelper` if e.g. an exception caused no `async` tasks
+  to be scheduled. The `AsyncHelper` is used by EventFlow to expose non-`async`
+  methods to developers and provide the means to call `async` methods from
+  a synchronous context without causing a deadlock. There's no change to any of
+  the `async` methods.
+
+  The `AsyncHelper` is used in the following methods.
+  - `ICommandBus.Publish`
+  - `IEventStore.LoadEvents`
+  - `IEventStore.LoadAggregate`
+  - `IEventStore.LoadAllEvents`
+  - `IJobRunner.Execute`
+  - `IReadModelPopulator.Populate`
+  - `IReadModelPopulator.Purge`
+  - `IQueryProcessor.Process`
+
+### New in 0.24.1563 (released 2016-01-17)
 
  * Breaking: The following NuGet references have been updated
    - `EventStore.Client` v3.4.0 (up from v3.0.2)

--- a/Source/EventFlow.Tests/EventFlow.Tests.csproj
+++ b/Source/EventFlow.Tests/EventFlow.Tests.csproj
@@ -40,6 +40,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EventFlowTests.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="UnitTests\Commands\CommandDefinitionServiceTests.cs" />
     <Compile Include="UnitTests\Configuration\Decorators\DecoratorServiceTests.cs" />
     <Compile Include="UnitTests\Configuration\ModuleRegistrationTests.cs" />
+    <Compile Include="UnitTests\Core\AsyncHelperTests.cs" />
     <Compile Include="UnitTests\Core\CircularBufferTests.cs" />
     <Compile Include="UnitTests\Core\IdentityTests.cs" />
     <Compile Include="UnitTests\Core\ReflectionHelperTests.cs" />

--- a/Source/EventFlow.Tests/UnitTests/Core/AsyncHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/AsyncHelperTests.cs
@@ -150,7 +150,7 @@ namespace EventFlow.Tests.UnitTests.Core
             var result = PotentialDeadlockAsync("deadlock").Result;
 
             // Assert
-            // Will be thrown
+            // Will NOT be thrown
             throw new Exception(result);
         }
 
@@ -165,7 +165,7 @@ namespace EventFlow.Tests.UnitTests.Core
             var result = PotentialDeadlockAsync("deadlock").GetAwaiter().GetResult();
 
             // Assert
-            // Will be thrown
+            // Will NOT be thrown
             throw new Exception(result);
         }
 

--- a/Source/EventFlow.Tests/UnitTests/Core/AsyncHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/AsyncHelperTests.cs
@@ -1,0 +1,188 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015 Rasmus Mikkelsen
+// Copyright (c) 2015 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using EventFlow.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.UnitTests.Core
+{
+    public class AsyncHelperTests
+    {
+        [Test]
+        public void EmptyIsExpectedToFinish()
+        {
+            using (AsyncHelper.Wait)
+            {
+                // Left empty
+            }
+        }
+
+        [Test, Description("Have a look at ReferenceDeadlockImplementation1 and ReferenceDeadlockImplementation2")]
+        public void DoesNotDeadlock()
+        {
+            // Arrange
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+            string result = null;
+
+            // Act
+            using (var a = AsyncHelper.Wait)
+            {
+                a.Run(PotentialDeadlockAsync("no deadlock"), r => result = r);
+            }
+
+            // Assert
+            // Expected to actually finish
+            result.Should().Be("no deadlock");
+        }
+
+        [Test]
+        public void ThrowsAggregateExceptionForTwoExceptions()
+        {
+            // Act + Assert
+            Assert.Throws<AggregateException>(() =>
+            {
+                using (var a = AsyncHelper.Wait)
+                {
+                    a.Run(Task.WhenAll(ThrowsTestExceptionAsync(), ThrowsTestExceptionAsync()));
+                }
+            });
+        }
+
+        [Test]
+        public void ThrowsAggregateExceptionForOneException()
+        {
+            // Act + Assert
+            Assert.Throws<AggregateException>(() =>
+            {
+                using (var a = AsyncHelper.Wait)
+                {
+                    a.Run(ThrowsTestExceptionAsync());
+                }
+            });
+        }
+
+        [Test]
+        public void AsyncOperationIsAllowedToFinish()
+        {
+            // Arrange
+            var wasExecuted = false;
+
+            // Act
+            using (var a = AsyncHelper.Wait)
+            {
+                a.Run(Task.Run(async () =>
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(0.5)).ConfigureAwait(true);
+                        wasExecuted = true;
+                    }));
+            }
+
+            // Assert
+            wasExecuted.Should().BeTrue();
+        }
+
+        [Test]
+        public void NestedAsyncOperationsAreAllowedToFinish()
+        {
+            // Arrange
+            var rootWasExecuted = false;
+            var levelsWereExecuted = new bool[10];
+
+            // Act
+            using (var a = AsyncHelper.Wait)
+            {
+                a.Run(Enumerable.Range(0, 10).Aggregate(
+                    Task.Run(async () =>
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(true);
+                        rootWasExecuted = true;
+                        Console.WriteLine("Root task done");
+                    }),
+                    (t, i) => Task.Run(async () =>
+                    {
+                        await t.ConfigureAwait(true);
+                        await Task.Delay(TimeSpan.FromSeconds(0.1)).ConfigureAwait(true);
+                        Console.WriteLine($"Task level {i} done");
+                        levelsWereExecuted[i] = true;
+                    })));
+            }
+
+            // Assert
+            rootWasExecuted.Should().BeTrue();
+            levelsWereExecuted.All(b => b).Should().BeTrue();
+        }
+
+        [Test, Explicit("For reference: Will deadlock!")]
+        public void ReferenceDeadlockImplementation1()
+        {
+            // Arrange
+            var synchronizationContext = new DispatcherSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            // Act
+            var result = PotentialDeadlockAsync("deadlock").Result;
+
+            // Assert
+            // Will be thrown
+            throw new Exception(result);
+        }
+
+        [Test, Explicit("For reference: Will deadlock!")]
+        public void ReferenceDeadlockImplementation2()
+        {
+            // Arrange
+            var synchronizationContext = new DispatcherSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            // Act
+            var result = PotentialDeadlockAsync("deadlock").GetAwaiter().GetResult();
+
+            // Assert
+            // Will be thrown
+            throw new Exception(result);
+        }
+
+        private static async Task ThrowsTestExceptionAsync()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(true);
+            throw new TestException();
+        }
+
+        private static async Task<string> PotentialDeadlockAsync(string returnValue)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(true);
+            return returnValue;
+        }
+
+        public class TestException : Exception
+        {
+        }
+    }
+}

--- a/Source/EventFlow/Core/AsyncHelper.cs
+++ b/Source/EventFlow/Core/AsyncHelper.cs
@@ -1,5 +1,9 @@
-﻿// Copyright 2013 Tom Jacques
-// https://github.com/tejacques/AsyncBridge
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2013 Tom Jacques (https://github.com/tejacques/AsyncBridge)
+// Copyright (c) 2015-2016 Rasmus Mikkelsen
+// Copyright (c) 2015-2016 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -43,6 +47,7 @@ namespace EventFlow.Core
             private readonly ExclusiveSynchronizationContext _currentContext;
             private readonly SynchronizationContext _oldContext;
             private int _taskCount;
+            private bool _hasAsyncTasks;
 
             /// <summary>
             /// Constructs the AsyncBridge by capturing the current
@@ -64,6 +69,7 @@ namespace EventFlow.Core
             /// <param name="callback">Optional callback</param>
             public void Run(Task task, Action<Task> callback = null)
             {
+                _hasAsyncTasks = true;
                 _currentContext.Post(
                     async _ =>
                         {
@@ -139,7 +145,10 @@ namespace EventFlow.Core
             {
                 try
                 {
-                    _currentContext.BeginMessageLoop();
+                    if (_hasAsyncTasks)
+                    {
+                        _currentContext.BeginMessageLoop();
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
* Fixed: Deadlock in `AsyncHelper` if e.g. an exception caused no `async` tasks
  to be scheduled. The `AsyncHelper` is used by EventFlow to expose non-`async`
  methods to developers and provide the means to call `async` methods from
  a synchronous context without causing a deadlock. There's no change to any of
  the `async` methods.

  The `AsyncHelper` is used in the following methods.
  - `ICommandBus.Publish`
  - `IEventStore.LoadEvents`
  - `IEventStore.LoadAggregate`
  - `IEventStore.LoadAllEvents`
  - `IJobRunner.Execute`
  - `IReadModelPopulator.Populate`
  - `IReadModelPopulator.Purge`
  - `IQueryProcessor.Process`