### PR TITLE
Allow developers to control job display names in Hangfire

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,10 @@
-### New in 0.26 (not released yet)
+### New in 0.27 (not released yet)
+
+ * New: Configure Hangfire job display names by implementing
+   `IJobDisplayNameBuilder`. The default implementation uses job name and
+   version.
+
+### New in 0.26.1714 (released 2016-02-20)
 
  * Breaking: Renamed `MssqlMigrationException` to `SqlMigrationException`
  * Breaking: Renamed `SqlErrorRetryStrategy` to `MsSqlErrorRetryStrategy`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 ### New in 0.27 (not released yet)
 
  * New: Configure Hangfire job display names by implementing
-   `IJobDisplayNameBuilder`. The default implementation uses job name and
-   version.
+   `IJobDisplayNameBuilder`. The default implementation uses job description
+   name and version
 
 ### New in 0.26.1714 (released 2016-02-20)
 

--- a/Source/EventFlow.Hangfire.Tests/EventFlow.Hangfire.Tests.csproj
+++ b/Source/EventFlow.Hangfire.Tests/EventFlow.Hangfire.Tests.csproj
@@ -97,6 +97,72 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>
+        <Reference Include="System.Net.Http.Formatting">
+          <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Web.Http">
+          <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core\lib\net45\System.Web.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.Web.Http.Owin">
+          <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin\lib\net45\System.Web.Http.Owin.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Owin">
+          <HintPath>..\..\packages\Microsoft.Owin\lib\net45\Microsoft.Owin.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Owin.Host.HttpListener">
+          <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Owin.Hosting">
+          <HintPath>..\..\packages\Microsoft.Owin.Hosting\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
           <Private>True</Private>

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobFlow.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobFlow.cs
@@ -104,7 +104,7 @@ namespace EventFlow.Hangfire.Tests.Integration
                         if (!testAggregate.IsNew)
                         {
                             var jobHtml = await GetAsync(new Uri($"http://localhost:9001/hangfire/jobs/details/{jobId.Value}")).ConfigureAwait(false);
-                            jobHtml.Should().Contain("PublishCommand v1");
+                            jobHtml.Should().Contain("<h1 class=\"page-header\">&quot;PublishCommand v1&quot;</h1>");
 
                             Assert.Pass();
                         }

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobFlow.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobFlow.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Commands;
 using EventFlow.TestHelpers.Aggregates.ValueObjects;
+using Hangfire.SqlServer;
 
 namespace EventFlow.Hangfire.Tests.Integration
 {
@@ -65,11 +66,21 @@ namespace EventFlow.Hangfire.Tests.Integration
                 .UseHangfireJobScheduler()
                 .CreateResolver(false))
             {
+                var sqlServerStorageOptions = new SqlServerStorageOptions
+                    {
+                        QueuePollInterval = TimeSpan.FromSeconds(1),
+                    };
+                var backgroundJobServerOptions = new BackgroundJobServerOptions
+                    {
+                        SchedulePollingInterval = TimeSpan.FromSeconds(1),
+                    };
+
                 GlobalConfiguration.Configuration
-                    .UseSqlServerStorage(_msSqlDatabase.ConnectionString.Value)
+                    .UseSqlServerStorage(_msSqlDatabase.ConnectionString.Value, sqlServerStorageOptions)
                     .UseActivator(new EventFlowResolverActivator(resolver));
 
-                using (new BackgroundJobServer())
+
+                using (new BackgroundJobServer(backgroundJobServerOptions))
                 {
                     // Arrange
                     var testId = ThingyId.New;

--- a/Source/EventFlow.Hangfire.Tests/paket.references
+++ b/Source/EventFlow.Hangfire.Tests/paket.references
@@ -1,5 +1,6 @@
 Hangfire.Core
 Hangfire.SqlServer
+Microsoft.AspNet.WebApi.OwinSelfHost
 Newtonsoft.Json
 Owin
 

--- a/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
+++ b/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
@@ -49,6 +49,10 @@
     <Compile Include="Integration\EventFlowResolverActivator.cs" />
     <Compile Include="Integration\HangfireJobId.cs" />
     <Compile Include="Integration\HangfireJobScheduler.cs" />
+    <Compile Include="Integration\IJobDisplayNameBuilder.cs" />
+    <Compile Include="Integration\IHangfireJobRunner.cs" />
+    <Compile Include="Integration\JobDisplayNameBuilder.cs" />
+    <Compile Include="Integration\HangfireJobRunner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
@@ -20,33 +20,25 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
-using System;
-using EventFlow.Hangfire.Integration;
-using EventFlow.Jobs;
-using Hangfire;
+//
 
-namespace EventFlow.Hangfire.Extensions
+using EventFlow.Jobs;
+
+namespace EventFlow.Hangfire.Integration
 {
-    public static class EventFlowOptionsHangfireExtensions
+    public class HangfireJobRunner : IHangfireJobRunner
     {
-        [Obsolete("Please use the correctly spelled 'UseHangfireJobScheduler()' instead")]
-        public static IEventFlowOptions UseHandfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
+        private readonly IJobRunner _jobRunner;
+
+        public HangfireJobRunner(
+            IJobRunner jobRunner)
         {
-            return eventFlowOptions.UseHangfireJobScheduler();
+            _jobRunner = jobRunner;
         }
 
-        public static IEventFlowOptions UseHangfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
+        public void Execute(string displayName, string jobName, int version, string job)
         {
-            return eventFlowOptions.RegisterServices(sr =>
-                {
-                    sr.Register<IJobScheduler, HangfireJobScheduler>();
-                    sr.Register<IHangfireJobRunner, HangfireJobRunner>();
-                    sr.Register<IJobDisplayNameBuilder, JobDisplayNameBuilder>();
-                    sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
-                });
+            _jobRunner.Execute(jobName, version, job);
         }
     }
 }

--- a/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
@@ -20,33 +20,15 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
-using System;
-using EventFlow.Hangfire.Integration;
-using EventFlow.Jobs;
-using Hangfire;
+//
 
-namespace EventFlow.Hangfire.Extensions
+using System.ComponentModel;
+
+namespace EventFlow.Hangfire.Integration
 {
-    public static class EventFlowOptionsHangfireExtensions
+    public interface IHangfireJobRunner
     {
-        [Obsolete("Please use the correctly spelled 'UseHangfireJobScheduler()' instead")]
-        public static IEventFlowOptions UseHandfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
-        {
-            return eventFlowOptions.UseHangfireJobScheduler();
-        }
-
-        public static IEventFlowOptions UseHangfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
-        {
-            return eventFlowOptions.RegisterServices(sr =>
-                {
-                    sr.Register<IJobScheduler, HangfireJobScheduler>();
-                    sr.Register<IHangfireJobRunner, HangfireJobRunner>();
-                    sr.Register<IJobDisplayNameBuilder, JobDisplayNameBuilder>();
-                    sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
-                });
-        }
+        [DisplayName("{0}")]
+        void Execute(string displayName, string jobName, int version, string job);
     }
 }

--- a/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
@@ -20,33 +20,16 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
-using System;
-using EventFlow.Hangfire.Integration;
+//
+
+using System.Threading;
+using System.Threading.Tasks;
 using EventFlow.Jobs;
-using Hangfire;
 
-namespace EventFlow.Hangfire.Extensions
+namespace EventFlow.Hangfire.Integration
 {
-    public static class EventFlowOptionsHangfireExtensions
+    public interface IJobDisplayNameBuilder
     {
-        [Obsolete("Please use the correctly spelled 'UseHangfireJobScheduler()' instead")]
-        public static IEventFlowOptions UseHandfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
-        {
-            return eventFlowOptions.UseHangfireJobScheduler();
-        }
-
-        public static IEventFlowOptions UseHangfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
-        {
-            return eventFlowOptions.RegisterServices(sr =>
-                {
-                    sr.Register<IJobScheduler, HangfireJobScheduler>();
-                    sr.Register<IHangfireJobRunner, HangfireJobRunner>();
-                    sr.Register<IJobDisplayNameBuilder, JobDisplayNameBuilder>();
-                    sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
-                });
-        }
+        Task<string> GetDisplayNameAsync(IJob job, JobDefinition jobDefinition, CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
@@ -20,33 +20,19 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// 
-using System;
-using EventFlow.Hangfire.Integration;
+//
+
+using System.Threading;
+using System.Threading.Tasks;
 using EventFlow.Jobs;
-using Hangfire;
 
-namespace EventFlow.Hangfire.Extensions
+namespace EventFlow.Hangfire.Integration
 {
-    public static class EventFlowOptionsHangfireExtensions
+    public class JobDisplayNameBuilder : IJobDisplayNameBuilder
     {
-        [Obsolete("Please use the correctly spelled 'UseHangfireJobScheduler()' instead")]
-        public static IEventFlowOptions UseHandfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
+        public Task<string> GetDisplayNameAsync(IJob job, JobDefinition jobDefinition, CancellationToken cancellationToken)
         {
-            return eventFlowOptions.UseHangfireJobScheduler();
-        }
-
-        public static IEventFlowOptions UseHangfireJobScheduler(
-            this IEventFlowOptions eventFlowOptions)
-        {
-            return eventFlowOptions.RegisterServices(sr =>
-                {
-                    sr.Register<IJobScheduler, HangfireJobScheduler>();
-                    sr.Register<IHangfireJobRunner, HangfireJobRunner>();
-                    sr.Register<IJobDisplayNameBuilder, JobDisplayNameBuilder>();
-                    sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
-                });
+            return Task.FromResult($"{jobDefinition.Name} v{jobDefinition.Version}");
         }
     }
 }

--- a/Source/EventFlow.Sql.Tests/EventFlow.Sql.Tests.csproj
+++ b/Source/EventFlow.Sql.Tests/EventFlow.Sql.Tests.csproj
@@ -58,6 +58,20 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <ProjectReference Include="..\EventFlow.Sql\EventFlow.Sql.csproj">
+      <Project>{8ec9d877-7351-4c7e-87a8-29bbd3d7febb}</Project>
+      <Name>EventFlow.Sql</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EventFlow.TestHelpers\EventFlow.TestHelpers.csproj">
+      <Project>{571d291c-5e4c-43af-855f-7c4e2f318f4c}</Project>
+      <Name>EventFlow.TestHelpers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EventFlow\EventFlow.csproj">
+      <Project>{11131251-778d-4d2e-bdd1-4844a789bca9}</Project>
+      <Name>EventFlow</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>
@@ -283,19 +297,5 @@
       <Private>True</Private>
       <Paket>True</Paket>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\EventFlow.Sql\EventFlow.Sql.csproj">
-      <Project>{8ec9d877-7351-4c7e-87a8-29bbd3d7febb}</Project>
-      <Name>EventFlow.Sql</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\EventFlow.TestHelpers\EventFlow.TestHelpers.csproj">
-      <Project>{571d291c-5e4c-43af-855f-7c4e2f318f4c}</Project>
-      <Name>EventFlow.TestHelpers</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\EventFlow\EventFlow.csproj">
-      <Project>{11131251-778d-4d2e-bdd1-4844a789bca9}</Project>
-      <Name>EventFlow</Name>
-    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -76,7 +76,6 @@
       <Name>EventFlow</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 init:
   - git config --global core.autocrlf input
 
-version: 0.26.{build}
+version: 0.27.{build}
 
 before_build:
   - cmd: netsh http add urlacl url=http://+:2113/ user=Everyone


### PR DESCRIPTION
Developers can implement a custom `IJobDisplayNameBuilder` and control how a job display name is created.

@ylbillyli Would something like this work for #205?