### PR TITLE
[PoC] reliable event delivery

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,6 @@ If you think your name is missing from the list, create a pull-request.
 
 * MongoDB cleanup and move to main repository
 
+### [Przemysław Andruszewski](https://github.com/przemyslawandruszewski)
+
+* SQL Server and PostgreSQL query generation cleanup

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ share it by creating an issue with the link.
 * **Why _not_ to implement "unit of work" in DDD**
   * [Unit Of Work is the new Singleton](https://blog.sapiensworks.com/post/2014/06/04/Unit-Of-Work-is-the-new-Singleton.aspx)
     by Mike Mogosanu
-  * [The Unit of Work and Transactions In Domain-Driven Design](https://blog.sapiensworks.com/post/2015/09/02/DDD-and-UoW/)
+  * [The Unit of Work and Transactions In Domain-Driven Design](https://blog.sapiensworks.com/post/2015/09/02/DDD-and-UoW)
     by Mike Mogosanu
 
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ to the documentation.
 * [**Read models:**](https://docs.geteventflow.net/ReadStores.html)
   Denormalized representation of aggregate events optimized for reading fast.
   Currently there is support for these read model storage types.
+  For the SQL storage types the queries are being generated automatically with quoted columns and table names.
   * [Elasticsearch](https://docs.geteventflow.net/ReadStores.html#elasticsearch)
   * [In-memory](https//docs.geteventflow.net/ReadStores.html#in-memory) - only for test
   * [Microsoft SQL Server](https://docs.geteventflow.net/ReadStores.html#microsoft-sql-server)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ the [do’s and don’ts](https://docs.geteventflow.net/DosAndDonts.html) and th
   * **[RestAirline:](https://github.com/twzhangyang/RestAirline)**
 	A classic DDD with CQRS-ES, Hypermedia API project based on EventFlow. It's targeted to ASP.NET Core 2.2 and can be deployed to docker and k8s.
 	
+* **[Full Example:](https://github.com/OKTAYKIR/EventFlow.Example)**
+	A console application on .NET Core 2.2. You can up the services using [docker-compose file](https://github.com/OKTAYKIR/EventFlow.Example/blob/master/build/docker-compose.yml). Docker-compose file include EventStore, RabbitMq, MongoDb, and PostgreSQL. It include following EventFlow concepts:
+	* Aggregates
+	* Command bus and commands
+	* Synchronous subscriber
+	* Event store ([GES](https://eventstore.com/))
+	* In-memory read model.
+	* Snapshots ([MongoDb](https://www.mongodb.com/))
+	* Sagas
+	* Event publising (In-memory, [RabbitMq](https://www.rabbitmq.com/))
+	* Metadata
+	* Command bus decorator, custom value object, custom execution result, ...
+	
 ### Overview
 
 Here is a list of the EventFlow concepts. Use the links to navigate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### New in 0.78 (not released yet)
 
-* _Nothing yet_
+* Updated LibLog provider to support structured logging with NLog 4.5. 
+  Reduced memory allocations for log4net-provider.
 
 ### New in 0.77.4077 (released 2019-12-10)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 * New: Updated LibLog provider to support structured logging with NLog 4.5. 
   Reduced memory allocations for log4net-provider
+* New: Made several methods in `AggregateRoot<,>` `virtual` to allow
+  easier customization
 * Fixed: Added quoting to the SQL query generator for the column names
 ```sql
   -- query before the fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 ### New in 0.78 (not released yet)
 
-* Updated LibLog provider to support structured logging with NLog 4.5. 
-  Reduced memory allocations for log4net-provider.
-* Added quoting to the SQL query generator for the column names
+* New: Updated LibLog provider to support structured logging with NLog 4.5. 
+  Reduced memory allocations for log4net-provider
+* Fixed: Added quoting to the SQL query generator for the column names
 ```sql
   -- query before the fix
     UPDATE [ReadModel-TestAttributes]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@
     SET [UpdatedTime] = @UpdatedTime
     WHERE [Id] = @Id
   ```
+* Fixed: Do not log about event upgraders if none is found for an event
+* Fixed: Add default `null` predicate to `AddCommands` and `AddJobs`
 
 ### New in 0.77.4077 (released 2019-12-10)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,18 @@
 
 * Updated LibLog provider to support structured logging with NLog 4.5. 
   Reduced memory allocations for log4net-provider.
+* Added quoting to the SQL query generator for the column names
+```sql
+  -- query before the fix
+    UPDATE [ReadModel-TestAttributes]
+    SET UpdatedTime = @UpdatedTime
+    WHERE Id = @Id
+  
+  -- query after the fix
+    UPDATE [ReadModel-TestAttributes]
+    SET [UpdatedTime] = @UpdatedTime
+    WHERE [Id] = @Id
+  ```
 
 ### New in 0.77.4077 (released 2019-12-10)
 

--- a/Source/EventFlow.AspNetCore/EventFlow.AspNetCore.csproj
+++ b/Source/EventFlow.AspNetCore/EventFlow.AspNetCore.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
+++ b/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/EventFlow.DependencyInjection/EventFlow.DependencyInjection.csproj
+++ b/Source/EventFlow.DependencyInjection/EventFlow.DependencyInjection.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
+++ b/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NEST" Version="6.1.0" />
     <PackageReference Include="newtonsoft.json" Version="11.0.2" />    
   </ItemGroup>

--- a/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
+++ b/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -57,12 +57,14 @@ namespace EventFlow.EntityFramework.EventStores
         public async Task<AllCommittedEventsPage> LoadAllCommittedEvents(GlobalPosition globalPosition, int pageSize,
             CancellationToken cancellationToken)
         {
-            return await LoadAllEvents(globalPosition, pageSize, null, cancellationToken);
+            return await LoadAllEvents(globalPosition, pageSize, null, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         public async Task<AllCommittedEventsPage> LoadAllUnconfirmedEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken)
         {
-            return await LoadAllEvents(globalPosition, pageSize, false, cancellationToken);
+            return await LoadAllEvents(globalPosition, pageSize, false, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         protected async Task<AllCommittedEventsPage> LoadAllEvents(GlobalPosition globalPosition, int pageSize,

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -1,19 +1,19 @@
 ﻿// The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2018 Rasmus Mikkelsen
 // Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -157,7 +157,7 @@ namespace EventFlow.EntityFramework.EventStores
                     .Set<EventEntity>()
                     .Where(e => e.AggregateId == id.Value
                                 && sequenceNumbers.Contains(e.AggregateSequenceNumber))
-                    .ToListAsync()
+                    .ToListAsync(cancellationToken)
                     .ConfigureAwait(false);
 
                 foreach (var @event in events)
@@ -211,7 +211,7 @@ namespace EventFlow.EntityFramework.EventStores
             {
                 var entities = await context.Set<EventEntity>()
                     .Where(e => e.AggregateId == id.Value)
-                    .Select(e => new EventEntity {GlobalSequenceNumber = e.GlobalSequenceNumber})
+                    .Select(e => new EventEntity { GlobalSequenceNumber = e.GlobalSequenceNumber })
                     .ToListAsync(cancellationToken)
                     .ConfigureAwait(false);
 

--- a/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
@@ -35,5 +35,6 @@ namespace EventFlow.EntityFramework.EventStores
         public string Data { get; set; }
         public string Metadata { get; set; }
         public int AggregateSequenceNumber { get; set; }
+        public bool Confirmed { get; set; }
     }
 }

--- a/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -34,6 +34,7 @@ namespace EventFlow.EntityFramework.Extensions
             var eventEntity = modelBuilder.Entity<EventEntity>();
             eventEntity.HasKey(e => e.GlobalSequenceNumber);
             eventEntity.HasIndex(e => new {e.AggregateId, e.AggregateSequenceNumber}).IsUnique();
+            eventEntity.HasIndex(e => e.Confirmed);
             return modelBuilder;
         }
 

--- a/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
+++ b/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
@@ -23,7 +23,7 @@
    
   <ItemGroup>
     <PackageReference Include="EventStore.Client" Version="5.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
+++ b/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.6.20" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="newtonsoft.json" Version="11.0.2" />
   </ItemGroup>
 

--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Driver" Version="2.7.2" />
   </ItemGroup>
 

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Owin/EventFlow.Owin.csproj
+++ b/Source/EventFlow.Owin/EventFlow.Owin.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -59,11 +59,6 @@ namespace EventFlow.PostgreSql.TestsHelpers
             environmentServer = "localhost";
             environmentPort = "5432";
             envrionmentUsername = "postgres";
-
-            environmentServer = "event-flow2.postgres.database.azure.com";
-            environmentPort = "5432";
-            environmentPassword = "event@Flow123";
-            envrionmentUsername = "eventFlow@event-flow2";
             
             connectionstringParts.Add(string.IsNullOrEmpty(environmentServer)
                 ? @"Server=localhost"

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -54,11 +54,17 @@ namespace EventFlow.PostgreSql.TestsHelpers
             var environmentPassword = Environment.GetEnvironmentVariable("HELPZ_POSTGRESQL_PASS");
             var envrionmentUsername = Environment.GetEnvironmentVariable("HELPZ_POSTGRESQL_USER", EnvironmentVariableTarget.Machine);
 
+            
 
             environmentServer = "localhost";
             environmentPort = "5432";
             envrionmentUsername = "postgres";
 
+            environmentServer = "event-flow2.postgres.database.azure.com";
+            environmentPort = "5432";
+            environmentPassword = "event@Flow123";
+            envrionmentUsername = "eventFlow@event-flow2";
+            
             connectionstringParts.Add(string.IsNullOrEmpty(environmentServer)
                 ? @"Server=localhost"
                 : $"Server={environmentServer}");

--- a/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
+++ b/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-postgresql" Version="4.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Npgsql" Version="4.0.2" />
   </ItemGroup>
 

--- a/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
+++ b/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
+++ b/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.109.1" />
   </ItemGroup>
 

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -42,7 +42,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateInsertSql<TestAttributesReadModel>();
 
             // Assert
-            sql.Should().Be("INSERT INTO [ReadModel-TestAttributes] (Id, UpdatedTime) VALUES (@Id, @UpdatedTime)");
+            sql.Should().Be("INSERT INTO [ReadModel-TestAttributes] ([Id], [UpdatedTime]) VALUES (@Id, @UpdatedTime)");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestAttributes] SET UpdatedTime = @UpdatedTime WHERE Id = @Id");
+            sql.Should().Be("UPDATE [ReadModel-TestAttributes] SET [UpdatedTime] = @UpdatedTime WHERE [Id] = @Id");
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestVersionedAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET FancyVersion = @FancyVersion WHERE CoolId = @CoolId AND FancyVersion = @_PREVIOUS_VERSION");
+            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
         }
 
         [Test]

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -62,7 +62,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestVersionedAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
+            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] = @FancyVersion WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
         }
 
         [Test]

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.2" />
     <PackageReference Include="dbup-core" Version="4.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.6'" Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.ComponentModel.Annotations" Version="4.4.1" />
   </ItemGroup>

--- a/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
@@ -1,0 +1,59 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventFlow.Sql.Extensions
+{
+    public static class SqlStringExtensions
+    {
+        public static IEnumerable<string> SelectToQuotedColumns(
+            this IEnumerable<string> columns,
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix)
+            => columns.Select(x => GetQuotedColumn(quotedIdentifierPrefix, quotedIdentifierSuffix, x));
+
+        public static IEnumerable<string> SelectToUpdateQuotedColumnsByParameters(
+            this IEnumerable<string> columns,
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix)
+            => columns.Select(
+                x => $"{GetQuotedColumn(quotedIdentifierPrefix, quotedIdentifierSuffix, x)} = {GetParameter(x)}");
+
+        public static IEnumerable<string> SelectToSqlParameters(this IEnumerable<string> columns)
+            => columns.Select(x => $"@{x}");
+
+        public static string JoinToSql(this IEnumerable<string> columns, string separator = ", ")
+            => string.Join(separator, columns);
+
+        private static string GetParameter(string value)
+            => $"@{value}";
+
+        private static string GetQuotedColumn(
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix,
+            string value)
+            => $"{quotedIdentifierPrefix}{value}{quotedIdentifierSuffix}";
+    }
+}

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2019 Rasmus Mikkelsen
-// Copyright (c) 2015-2019 eBay Software Foundation
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,16 +21,28 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using EventFlow.Sql.ReadModels;
-
-namespace EventFlow.PostgreSql.ReadModels
+namespace EventFlow.Sql.ReadModels
 {
-    public class PostgresReadModelSqlGenerator : ReadModelSqlGenerator
+    public class ReadModelSqlGeneratorConfiguration
     {
-        public PostgresReadModelSqlGenerator()
-            : base(new ReadModelSqlGeneratorConfiguration("\"", "\"", string.Empty, string.Empty))
+        public ReadModelSqlGeneratorConfiguration(
+            string tableQuotedIdentifierPrefix,
+            string tableQuotedIdentifierSuffix,
+            string columnQuotedIdentifierPrefix,
+            string columnQuotedIdentifierSuffix)
         {
+            TableQuotedIdentifierPrefix = tableQuotedIdentifierPrefix;
+            TableQuotedIdentifierSuffix = tableQuotedIdentifierSuffix;
+            ColumnQuotedIdentifierPrefix = columnQuotedIdentifierPrefix;
+            ColumnQuotedIdentifierSuffix = columnQuotedIdentifierSuffix;
         }
+
+        public string TableQuotedIdentifierPrefix { get; set; }
+
+        public string TableQuotedIdentifierSuffix { get; set; }
+
+        public string ColumnQuotedIdentifierPrefix { get; set; }
+
+        public string ColumnQuotedIdentifierSuffix { get; set; }
     }
 }

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.8.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -143,6 +143,12 @@ namespace EventFlow.Aggregates
                         cancellationToken)
                         .ConfigureAwait(false);
 
+                    if (_eventStore.IsReliable)
+                    {
+                        domainEvents = await _eventStore.LoadUndeliveredEventsAsync<TAggregate, TIdentity>(
+                            id, 1, cancellationToken).ConfigureAwait(false);
+                    }
+
                     return new AggregateUpdateResult<TExecutionResult>(
                         result,
                         domainEvents);
@@ -159,6 +165,13 @@ namespace EventFlow.Aggregates
                     aggregateUpdateResult.DomainEvents,
                     cancellationToken)
                     .ConfigureAwait(false);
+
+                if (_eventStore.IsReliable)
+                {
+                    await _eventStore.MarkEventsDeliveredAsync<TAggregate, TIdentity>(
+                        id, aggregateUpdateResult.DomainEvents.Select(a => a.Metadata.EventId).ToArray(), cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             return aggregateUpdateResult;

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -169,7 +169,7 @@ namespace EventFlow.Aggregates
                 if (_eventStore.IsReliable)
                 {
                     await _eventStore.MarkEventsDeliveredAsync<TAggregate, TIdentity>(
-                        id, aggregateUpdateResult.DomainEvents.Select(a => a.Metadata.EventId).ToArray(), cancellationToken)
+                        id, aggregateUpdateResult.DomainEvents.Select(a => a.Metadata).ToArray(), cancellationToken)
                         .ConfigureAwait(false);
                 }
             }

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -145,7 +145,7 @@ namespace EventFlow.Aggregates
 
                     if (_eventStore.IsReliable)
                     {
-                        domainEvents = await _eventStore.LoadUndeliveredEventsAsync<TAggregate, TIdentity>(
+                        domainEvents = await _eventStore.LoadUnconfirmedEventsAsync<TAggregate, TIdentity>(
                             id, 1, cancellationToken).ConfigureAwait(false);
                     }
 
@@ -168,7 +168,7 @@ namespace EventFlow.Aggregates
 
                 if (_eventStore.IsReliable)
                 {
-                    await _eventStore.MarkEventsDeliveredAsync<TAggregate, TIdentity>(
+                    await _eventStore.ConfirmEventsAsync<TAggregate, TIdentity>(
                         id, aggregateUpdateResult.DomainEvents.Select(a => a.Metadata).ToArray(), cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0">
       <PrivateAssets>All</PrivateAssets>

--- a/Source/EventFlow/EventStores/EventStoreBase.cs
+++ b/Source/EventFlow/EventStores/EventStoreBase.cs
@@ -119,19 +119,19 @@ namespace EventFlow.EventStores
 
         public async Task MarkEventsDeliveredAsync<TAggregate, TIdentity>(
             TIdentity id,
-            IReadOnlyCollection<IEventId> eventIds,
+            IReadOnlyCollection<IMetadata> eventMetadata,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
-            if (eventIds == null || eventIds.Count <= 0)
+            if (eventMetadata == null || eventMetadata.Count <= 0)
                 return;
 
             var aggregateType = typeof(TAggregate);
-            _log.Verbose(() => $"Marking {eventIds.Count} events as delivered for aggregate '{aggregateType.PrettyPrint()}' with ID '{id}'");
+            _log.Verbose(() => $"Marking {eventMetadata.Count} events as delivered for aggregate '{aggregateType.PrettyPrint()}' with ID '{id}'");
 
-            await _reliableEventPersistence.MarkEventsDeliveredAsync(id, eventIds, cancellationToken)
+            await _reliableEventPersistence.MarkEventsDeliveredAsync(id, eventMetadata, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/Source/EventFlow/EventStores/EventStoreBase.cs
+++ b/Source/EventFlow/EventStores/EventStoreBase.cs
@@ -39,13 +39,13 @@ namespace EventFlow.EventStores
         private readonly IAggregateFactory _aggregateFactory;
         private readonly IEventJsonSerializer _eventJsonSerializer;
         private readonly IEventPersistence _eventPersistence;
-        private readonly IReliableEventPersistance _reliableEventPersistance;
+        private readonly IReliableEventPersistence _reliableEventPersistence;
         private readonly ISnapshotStore _snapshotStore;
         private readonly IEventUpgradeManager _eventUpgradeManager;
         private readonly ILog _log;
         private readonly IReadOnlyCollection<IMetadataProvider> _metadataProviders;
 
-        public bool IsReliable => _reliableEventPersistance != null;
+        public bool IsReliable => _reliableEventPersistence != null;
 
         public EventStoreBase(
             ILog log,
@@ -54,11 +54,11 @@ namespace EventFlow.EventStores
             IEventUpgradeManager eventUpgradeManager,
             IEnumerable<IMetadataProvider> metadataProviders,
             IEventPersistence eventPersistence,
-            IReliableEventPersistance reliableEventPersistance,
+            IReliableEventPersistence reliableEventPersistence,
             ISnapshotStore snapshotStore)
         {
             _eventPersistence = eventPersistence;
-            _reliableEventPersistance = reliableEventPersistance;
+            _reliableEventPersistence = reliableEventPersistence;
             _snapshotStore = snapshotStore;
             _log = log;
             _aggregateFactory = aggregateFactory;
@@ -80,7 +80,7 @@ namespace EventFlow.EventStores
 
             if (uncommittedDomainEvents == null || !uncommittedDomainEvents.Any())
             {
-                return new IDomainEvent<TAggregate, TIdentity>[] {};
+                return new IDomainEvent<TAggregate, TIdentity>[] { };
             }
 
             var aggregateType = typeof(TAggregate);
@@ -131,7 +131,7 @@ namespace EventFlow.EventStores
             var aggregateType = typeof(TAggregate);
             _log.Verbose(() => $"Marking {eventIds.Count} events as delivered for aggregate '{aggregateType.PrettyPrint()}' with ID '{id}'");
 
-            await _reliableEventPersistance.MarkEventsDeliveredAsync(id, eventIds, cancellationToken)
+            await _reliableEventPersistence.MarkEventsDeliveredAsync(id, eventIds, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -161,7 +161,7 @@ namespace EventFlow.EventStores
         {
             if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
 
-            var allCommittedEventsPage = await _reliableEventPersistance.LoadAllUndeliveredEvents(
+            var allCommittedEventsPage = await _reliableEventPersistence.LoadAllUndeliveredEvents(
                 globalPosition,
                 pageSize,
                 cancellationToken)
@@ -222,7 +222,7 @@ namespace EventFlow.EventStores
         {
             if (fromEventSequenceNumber < 1) throw new ArgumentOutOfRangeException(nameof(fromEventSequenceNumber), "Event sequence numbers start at 1");
 
-            var committedDomainEvents = await _reliableEventPersistance.LoadUndeliveredEventsAsync(
+            var committedDomainEvents = await _reliableEventPersistence.LoadUndeliveredEventsAsync(
                 id,
                 fromEventSequenceNumber,
                 cancellationToken)

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -68,12 +68,10 @@ namespace EventFlow.EventStores
 
         private IEnumerable<IDomainEvent> Upgrade(IEnumerable<IDomainEvent> domainEvents)
         {
-            // TODO: Clean this up!
-
             var domainEventList = domainEvents.ToList();
             if (!domainEventList.Any())
             {
-                return new IDomainEvent[] { };
+                return Enumerable.Empty<IDomainEvent>();
             }
 
             var eventUpgraders = domainEventList
@@ -91,6 +89,11 @@ namespace EventFlow.EventStores
                                     cache.Upgrade
                                 };
                         });
+
+            if (!eventUpgraders.Any())
+            {
+                return Enumerable.Empty<IDomainEvent>();
+            }
 
             _log.Verbose(() => string.Format(
                 "Upgrading {0} events and found these event upgraders to use: {1}",

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -44,7 +44,7 @@ namespace EventFlow.EventStores
 
         Task MarkEventsDeliveredAsync<TAggregate, TIdentity>(
             TIdentity id,
-            IReadOnlyCollection<IEventId> eventIds,
+            IReadOnlyCollection<IMetadata> eventMetadata,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -32,6 +32,8 @@ namespace EventFlow.EventStores
 {
     public interface IEventStore
     {
+        bool IsReliable { get; }
+
         Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> StoreAsync<TAggregate, TIdentity>(
             TIdentity id,
             IReadOnlyCollection<IUncommittedEvent> uncommittedDomainEvents,
@@ -40,7 +42,19 @@ namespace EventFlow.EventStores
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
 
+        Task MarkEventsDeliveredAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            IReadOnlyCollection<IEventId> eventIds,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
+
         Task<AllEventsPage> LoadAllEventsAsync(
+            GlobalPosition globalPosition,
+            int pageSize,
+            CancellationToken cancellationToken);
+
+        Task<AllEventsPage> LoadAllUndeliveredEvents(
             GlobalPosition globalPosition,
             int pageSize,
             CancellationToken cancellationToken);
@@ -52,6 +66,13 @@ namespace EventFlow.EventStores
             where TIdentity : IIdentity;
 
         Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> LoadEventsAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            int fromEventSequenceNumber,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity;
+
+        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> LoadUndeliveredEventsAsync<TAggregate, TIdentity>(
             TIdentity id,
             int fromEventSequenceNumber,
             CancellationToken cancellationToken)

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -42,9 +42,9 @@ namespace EventFlow.EventStores
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
 
-        Task MarkEventsDeliveredAsync<TAggregate, TIdentity>(
+        Task ConfirmEventsAsync<TAggregate, TIdentity>(
             TIdentity id,
-            IReadOnlyCollection<IMetadata> eventMetadata,
+            IReadOnlyCollection<IMetadata> eventsMetadata,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
@@ -54,7 +54,7 @@ namespace EventFlow.EventStores
             int pageSize,
             CancellationToken cancellationToken);
 
-        Task<AllEventsPage> LoadAllUndeliveredEvents(
+        Task<AllEventsPage> LoadAllUnconfirmedEvents(
             GlobalPosition globalPosition,
             int pageSize,
             CancellationToken cancellationToken);
@@ -72,7 +72,7 @@ namespace EventFlow.EventStores
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity;
 
-        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> LoadUndeliveredEventsAsync<TAggregate, TIdentity>(
+        Task<IReadOnlyCollection<IDomainEvent<TAggregate, TIdentity>>> LoadUnconfirmedEventsAsync<TAggregate, TIdentity>(
             TIdentity id,
             int fromEventSequenceNumber,
             CancellationToken cancellationToken)

--- a/Source/EventFlow/EventStores/IReliableEventPersistance.cs
+++ b/Source/EventFlow/EventStores/IReliableEventPersistance.cs
@@ -1,19 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EventFlow.Aggregates;
 using EventFlow.Core;
 
 namespace EventFlow.EventStores
 {
     public interface IReliableEventPersistance: IEventPersistence
     {
-        Task MarkEventsDeliveredAsync(IIdentity id, IReadOnlyCollection<SerializedEvent> serializedEvents, CancellationToken cancellationToken);
+        Task MarkEventsDeliveredAsync(
+            IIdentity id,
+            IReadOnlyCollection<IEventId> eventIds,
+            CancellationToken cancellationToken);
 
-        Task<AllCommittedEventsPage> LoadAllUndeliveredEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken);
+        Task<AllCommittedEventsPage> LoadAllUndeliveredEvents(
+            GlobalPosition globalPosition,
+            int pageSize,
+            CancellationToken cancellationToken);
 
-        Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadUndeliveredEventsAsync(IIdentity id, int fromEventSequenceNumber, CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadUndeliveredEventsAsync(
+            IIdentity id,
+            int fromEventSequenceNumber,
+            CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/EventStores/IReliableEventPersistance.cs
+++ b/Source/EventFlow/EventStores/IReliableEventPersistance.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Core;
+
+namespace EventFlow.EventStores
+{
+    public interface IReliableEventPersistance: IEventPersistence
+    {
+        Task MarkEventsDeliveredAsync(IIdentity id, IReadOnlyCollection<SerializedEvent> serializedEvents, CancellationToken cancellationToken);
+
+        Task<AllCommittedEventsPage> LoadAllUndeliveredEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken);
+
+        Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadUndeliveredEventsAsync(IIdentity id, int fromEventSequenceNumber, CancellationToken cancellationToken);
+    }
+}

--- a/Source/EventFlow/EventStores/IReliableEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IReliableEventPersistence.cs
@@ -8,17 +8,17 @@ namespace EventFlow.EventStores
 {
     public interface IReliableEventPersistence: IEventPersistence
     {
-        Task MarkEventsDeliveredAsync(
+        Task ConfirmEventsAsync(
             IIdentity id,
-            IReadOnlyCollection<IMetadata> eventMetadata,
+            IReadOnlyCollection<IMetadata> eventsMetadata,
             CancellationToken cancellationToken);
 
-        Task<AllCommittedEventsPage> LoadAllUndeliveredEvents(
+        Task<AllCommittedEventsPage> LoadAllUnconfirmedEvents(
             GlobalPosition globalPosition,
             int pageSize,
             CancellationToken cancellationToken);
 
-        Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadUndeliveredEventsAsync(
+        Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadUnconfirmedEventsAsync(
             IIdentity id,
             int fromEventSequenceNumber,
             CancellationToken cancellationToken);

--- a/Source/EventFlow/EventStores/IReliableEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IReliableEventPersistence.cs
@@ -10,7 +10,7 @@ namespace EventFlow.EventStores
     {
         Task MarkEventsDeliveredAsync(
             IIdentity id,
-            IReadOnlyCollection<IEventId> eventIds,
+            IReadOnlyCollection<IMetadata> eventMetadata,
             CancellationToken cancellationToken);
 
         Task<AllCommittedEventsPage> LoadAllUndeliveredEvents(

--- a/Source/EventFlow/EventStores/IReliableEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IReliableEventPersistence.cs
@@ -6,7 +6,7 @@ using EventFlow.Core;
 
 namespace EventFlow.EventStores
 {
-    public interface IReliableEventPersistance: IEventPersistence
+    public interface IReliableEventPersistence: IEventPersistence
     {
         Task MarkEventsDeliveredAsync(
             IIdentity id,

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
@@ -40,7 +40,7 @@ namespace EventFlow.Extensions
         public static IEventFlowOptions AddCommands(
             this IEventFlowOptions eventFlowOptions,
             Assembly fromAssembly,
-            Predicate<Type> predicate)
+            Predicate<Type> predicate = null)
         {
             predicate = predicate ?? (t => true);
             var commandTypes = fromAssembly

--- a/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
@@ -40,7 +40,7 @@ namespace EventFlow.Extensions
         public static IEventFlowOptions AddJobs(
             this IEventFlowOptions eventFlowOptions,
             Assembly fromAssembly,
-            Predicate<Type> predicate)
+            Predicate<Type> predicate = null)
         {
             predicate = predicate ?? (t => true);
             var jobTypes = fromAssembly


### PR DESCRIPTION
First iteration of Reliable Events for Crash Resilience #439 
Early feedback appreciated

specification originally from a comment https://github.com/eventflow/EventFlow/issues/439#issuecomment-572772200

I have been thinking. We are dealing with the Two Generals Problem ( https://en.wikipedia.org/wiki/Two_Generals'_Problem https://www.youtube.com/watch?v=IP-rGJKSZ3s ) which has been proven unsolvable. The way around it is outbox pattern https://medium.com/engineering-varo/event-driven-architecture-and-the-outbox-pattern-569e6fba7216 . The price that we need to pay for it is to attemp to redeliver events ad infinitum. 

The first step is to extend `IEventPersistance` interface to be able to:
1. list undelivered events
2. mark event as delivered
see suggested extension of interface: https://github.com/mbican/EventFlow/commit/97204b9f30f62a05cccd4d1c4bc03265f316150d

All `IEventPersistance` implementation needs to implement it natively because it needs to be atomic together with event persistance.

It is not only about read models. It is about all receivers of event from `DomainEventPublisher` (read stores, subscribers, sagas). also see #609 for `DomainEventPublisher` modifications 

New event delivery implementation in a somewhat backwards compatible way:
```
# unchanged, commit events
IEventPersistance.CommitEventsAsync(id, ...)

# load undelivered events for aggregate because also some previous events can be still undelivered
var events = IReliableEventPersistance.LoadUndeliveredEventsAsync(id, ...)

# unchanged, publish events
IDomainEventPublisher.PublishAsync(events)

# mark events as delivered (published)
IReliableEventPersistance.MarkEventsDeliveredAsync(id, events)
```
NOTE: We can stop after `IEventPersistance.CommitEventsAsync()` and let events to be delivered asynchronously by the background worker

and/or delivery of events in a background worker in infinte loop:
```
while(true){
    var events = IReliableEventPersistance.LoadAllUndeliveredEvents()
    IDomainEventPublisher.PublishAsync(events)
    IReliableEventPersistance.MarkEventsDeliveredAsync(events)
}
```

So I think the most work will be with all the various `EventPersistance` implementations the change in the EventFlow core should be relatively simple. I can try to provide a prototype of the core change

And yes, it can happen that event will be delivered multiple times (unsolvable Two Generals' Problem). Receiver just has to deal with that e.g. by remembering ids of processed events.
I would even go as far as recommending to call `IDomainEventPublisher.PublishAsync(events)` always twice in Debug build so all code is well tested for duplicate event delivery