### PR TITLE
Upgrading to EventStore 20.6.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### New in 0.81 (not released yet)
 
 * Fixed: You can now create `Id : Identity<Id>`
+* EventStore has been updated to Nuget Library 20.6.1
+  and a UseEventStoreSubscriptions extensions has been added to help subscribe to stream
+  events based on a filter and then publish them to your internal microservices (pubsub)
 
 ### New in 0.80.4377 (released 2020-10-01)
 

--- a/Source/EventFlow.EventStores.EventStore/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow.EventStores.EventStore/Aggregates/AggregateStore.cs
@@ -1,0 +1,196 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Configuration;
+using EventFlow.Configuration.Cancellation;
+using EventFlow.Core;
+using EventFlow.Core.RetryStrategies;
+using EventFlow.Exceptions;
+using EventFlow.Extensions;
+using EventFlow.Logs;
+using EventFlow.Snapshots;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventFlow.EventStores.EventStore.Aggregates
+{
+    public class AggregateStore : IAggregateStore
+    {
+        private static readonly IReadOnlyCollection<IDomainEvent> EmptyDomainEventCollection = new IDomainEvent[] { };
+        private readonly ILog _log;
+        private readonly IResolver _resolver;
+        private readonly IAggregateFactory _aggregateFactory;
+        private readonly IEventStore _eventStore;
+        private readonly ISnapshotStore _snapshotStore;
+        private readonly ITransientFaultHandler<IOptimisticConcurrencyRetryStrategy> _transientFaultHandler;
+        private readonly ICancellationConfiguration _cancellationConfiguration;
+        private readonly IEventFlowConfiguration _eventFlowConfiguration;
+
+        public AggregateStore(
+            ILog log,
+            IResolver resolver,
+            IAggregateFactory aggregateFactory,
+            IEventStore eventStore,
+            ISnapshotStore snapshotStore,
+            ITransientFaultHandler<IOptimisticConcurrencyRetryStrategy> transientFaultHandler,
+            ICancellationConfiguration cancellationConfiguration,
+            IEventFlowConfiguration eventFlowConfiguration)
+        {
+            _log = log;
+            _resolver = resolver;
+            _aggregateFactory = aggregateFactory;
+            _eventStore = eventStore;
+            _snapshotStore = snapshotStore;
+            _transientFaultHandler = transientFaultHandler;
+            _cancellationConfiguration = cancellationConfiguration;
+            _eventFlowConfiguration = eventFlowConfiguration;
+        }
+
+        public async Task<TAggregate> LoadAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+        {
+            var aggregate = await _aggregateFactory.CreateNewAggregateAsync<TAggregate, TIdentity>(id).ConfigureAwait(false);
+            await aggregate.LoadAsync(_eventStore, _snapshotStore, cancellationToken).ConfigureAwait(false);
+            return aggregate;
+        }
+
+        public async Task<IReadOnlyCollection<IDomainEvent>> UpdateAsync<TAggregate, TIdentity>(
+            TIdentity id,
+            ISourceId sourceId,
+            Func<TAggregate, CancellationToken, Task> updateAggregate,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+        {
+            var aggregateUpdateResult = await UpdateAsync<TAggregate, TIdentity, IExecutionResult>(
+                id,
+                sourceId,
+                async (a, c) =>
+                    {
+                        await updateAggregate(a, c).ConfigureAwait(false);
+                        return ExecutionResult.Success();
+                    },
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return aggregateUpdateResult.DomainEvents;
+        }
+
+        public async Task<IAggregateUpdateResult<TExecutionResult>> UpdateAsync<TAggregate, TIdentity, TExecutionResult>(
+            TIdentity id,
+            ISourceId sourceId,
+            Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            var aggregateUpdateResult = await _transientFaultHandler.TryAsync(
+                async c =>
+                {
+                    var aggregate = await LoadAsync<TAggregate, TIdentity>(id, c).ConfigureAwait(false);
+                    if (aggregate.HasSourceId(sourceId))
+                    {
+                        throw new DuplicateOperationException(
+                            sourceId,
+                            id,
+                            $"Aggregate '{typeof(TAggregate).PrettyPrint()}' has already had operation '{sourceId}' performed");
+                    }
+
+                    cancellationToken = _cancellationConfiguration.Limit(cancellationToken, CancellationBoundary.BeforeUpdatingAggregate);
+
+                    var result = await updateAggregate(aggregate, c).ConfigureAwait(false);
+                    if (!result.IsSuccess)
+                    {
+                        _log.Debug(() => $"Execution failed on aggregate '{typeof(TAggregate).PrettyPrint()}', disregarding any events emitted");
+                        return new AggregateUpdateResult<TExecutionResult>(
+                            result,
+                            EmptyDomainEventCollection);
+                    }
+
+                    cancellationToken = _cancellationConfiguration.Limit(cancellationToken, CancellationBoundary.BeforeCommittingEvents);
+                    
+                    try
+                    {
+                        var domainEvents = await aggregate.CommitAsync(
+                                _eventStore,
+                                _snapshotStore,
+                                sourceId,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        return new AggregateUpdateResult<TExecutionResult>(
+                            result,
+                            domainEvents);
+                    }
+                    catch (OptimisticConcurrencyException) when (!_eventFlowConfiguration.ForwardOptimisticConcurrencyExceptions)
+                    {
+                        throw;
+                    }
+                },
+                Label.Named("aggregate-update"),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return aggregateUpdateResult;
+        }
+
+        public async Task<IReadOnlyCollection<IDomainEvent>> StoreAsync<TAggregate, TIdentity>(
+            TAggregate aggregate,
+            ISourceId sourceId,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+        {
+            var domainEvents = await aggregate.CommitAsync(
+                _eventStore,
+                _snapshotStore,
+                sourceId,
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return domainEvents;
+        }
+        
+        internal class AggregateUpdateResult<TExecutionResult> : IAggregateUpdateResult<TExecutionResult>
+            where TExecutionResult : IExecutionResult
+        {
+            public TExecutionResult Result { get; }
+            public IReadOnlyCollection<IDomainEvent> DomainEvents { get; }
+
+            public AggregateUpdateResult(
+                TExecutionResult result,
+                IReadOnlyCollection<IDomainEvent> domainEvents)
+            {
+                Result = result;
+                DomainEvents = domainEvents;
+            }
+        }
+    }
+}

--- a/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
+++ b/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -21,7 +21,7 @@
   </PropertyGroup>
    
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="5.0.1" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="20.6.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.EventStores.EventStore/EventStoreEvent.cs
+++ b/Source/EventFlow.EventStores.EventStore/EventStoreEvent.cs
@@ -1,0 +1,33 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.EventStores.EventStore
+{
+    public class EventStoreEvent : ICommittedDomainEvent
+    {
+        public string AggregateId { get; set; }
+        public string Data { get; set; }
+        public string Metadata { get; set; }
+        public int AggregateSequenceNumber { get; set; }
+    }
+}

--- a/Source/EventFlow.EventStores.EventStore/Subscriptions/EventStoreCheckpointStore.cs
+++ b/Source/EventFlow.EventStores.EventStore/Subscriptions/EventStoreCheckpointStore.cs
@@ -1,0 +1,97 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventStore.Client;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.EventStores.EventStore.Subscriptions
+{
+    public class EventStoreCheckpointStore : IEventStoreCheckpointStore
+    {
+        const string CheckpointStreamPrefix = "$$checkpoint-";
+        readonly EventStoreClient _client;
+        readonly string _streamName;
+
+        public EventStoreCheckpointStore(
+            EventStoreClient client,
+            string subscriptionName)
+        {
+            _client = client;
+            _streamName = CheckpointStreamPrefix + subscriptionName;
+        }
+
+        public async Task<ulong?> GetCheckpoint()
+        {
+            var result = _client.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End, 1);
+
+            if (await result.ReadState == ReadState.StreamNotFound)
+                return null;
+
+            var eventData = await result.FirstAsync();
+
+            if (eventData.Equals(default(ResolvedEvent)))
+            {
+                await StoreCheckpoint(Position.Start.CommitPosition);
+                return null;
+            }
+
+            return Deserialize<Checkpoint>(eventData)?.Position;
+        }
+
+        public Task StoreCheckpoint(ulong? checkpoint)
+        {
+            var @event = new Checkpoint { Position = checkpoint };
+
+            var preparedEvent =
+                new EventData(
+                    Uuid.NewUuid(),
+                    "$checkpoint",
+                    Serialize(@event)
+                );
+
+            return _client.AppendToStreamAsync(
+                _streamName,
+                StreamState.Any,
+                new List<EventData> { preparedEvent }
+            );
+        }
+
+        class Checkpoint
+        {
+            public ulong? Position { get; set; }
+        }
+
+        private byte[] Serialize(object data) =>
+            Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+
+        public T Deserialize<T>(ResolvedEvent resolvedEvent)
+        {
+            var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data.ToArray());
+            return JsonConvert.DeserializeObject<T>(jsonData);
+        }
+    }
+}

--- a/Source/EventFlow.EventStores.EventStore/Subscriptions/EventStoreSubscriptionEventPublisher.cs
+++ b/Source/EventFlow.EventStores.EventStore/Subscriptions/EventStoreSubscriptionEventPublisher.cs
@@ -1,0 +1,128 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+using EventFlow.Logs;
+using EventFlow.Subscribers;
+using EventStore.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventFlow.EventStores.EventStore.Subscriptions
+{
+    public class EventStoreSubscriptionEventPublisher
+    {
+        private readonly EventStoreClient _client;
+        private StreamSubscription _subscription;
+        private readonly IEventFilter _eventFilter;
+        private readonly uint _checkpointInterval;
+        private readonly IEventStoreCheckpointStore _checkpointStore;
+        private readonly IEventJsonSerializer _eventJsonSerializer;
+        private readonly IDomainEventPublisher _domainEventPublisher;
+        private readonly ILog _log;
+
+        public EventStoreSubscriptionEventPublisher(
+            ILog log,
+            EventStoreClient client,
+            IEventFilter eventFilter,
+            uint checkpointInterval,
+            IEventStoreCheckpointStore checkpointStore,
+            IEventJsonSerializer eventJsonSerializer,
+            IDomainEventPublisher domainEventPublisher)
+        {
+            _log = log;
+            _client = client;
+            _checkpointStore = checkpointStore;
+            _eventFilter = eventFilter;
+            _checkpointInterval = checkpointInterval;
+            _eventJsonSerializer = eventJsonSerializer;
+            _domainEventPublisher = domainEventPublisher;
+        }
+
+        public async Task StartAsync()
+        {
+            var position = await _checkpointStore.GetCheckpoint();
+            
+            _log.Information($"Starting subscription on stream '$all' at checkpoint '{(position ?? 0)}' listening for events matching '{_eventFilter.ToString()}' ");
+
+            _subscription = await _client.SubscribeToAllAsync(
+                    position.HasValue 
+                        ? new Position(position.Value, position.Value) 
+                        : Position.Start,
+                    EventReceivedAsync,
+                    filterOptions: new SubscriptionFilterOptions(
+                        _eventFilter,
+                        checkpointInterval: _checkpointInterval,
+                        checkpointReached: CheckpointReached
+                    ),
+                    subscriptionDropped: SubscriptionDropped,
+                    resolveLinkTos: true);
+        }
+
+        private async Task EventReceivedAsync(StreamSubscription _, ResolvedEvent resolvedEvent, CancellationToken c)
+        {
+            try
+            {
+                var eventStoreEvent = new EventStoreEvent
+                {
+                    AggregateId = resolvedEvent.Event.EventStreamId,
+                    AggregateSequenceNumber = (int)resolvedEvent.Event.EventNumber.ToInt64(),
+                    Metadata = Encoding.UTF8.GetString(resolvedEvent.Event.Metadata.Span),
+                    Data = Encoding.UTF8.GetString(resolvedEvent.Event.Data.Span),
+                };
+
+                var deserializedEventStoreEvent = _eventJsonSerializer.Deserialize(eventStoreEvent);
+
+                await _domainEventPublisher.PublishAsync(new List<IDomainEvent> { deserializedEventStoreEvent }, new CancellationToken());
+            }
+            catch(Exception e)
+            {
+                _log.Error(e, $"Error while processing event '{resolvedEvent.Event.EventId}'");
+            }
+        }
+
+        private Task CheckpointReached(StreamSubscription _, Position position, CancellationToken c)
+        {
+            _checkpointStore.StoreCheckpoint(position.PreparePosition);
+
+            return Task.CompletedTask;
+        }
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+        private void SubscriptionDropped(StreamSubscription _, SubscriptionDroppedReason reason, Exception? c)
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+        {
+            _log.Information($"Dropping subscription on stream '$all' for the following reason: {reason}");
+        }
+
+        public void Stop()
+        {
+            _log.Information($"Stopping subscription on stream '$all'");
+
+            _subscription.Dispose();
+        }
+    }
+}

--- a/Source/EventFlow.EventStores.EventStore/Subscriptions/IEventStoreCheckpointStore.cs
+++ b/Source/EventFlow.EventStores.EventStore/Subscriptions/IEventStoreCheckpointStore.cs
@@ -1,0 +1,34 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading.Tasks;
+
+namespace EventFlow.EventStores.EventStore.Subscriptions
+{
+    public interface IEventStoreCheckpointStore
+    {
+        Task<ulong?> GetCheckpoint();
+
+        Task StoreCheckpoint(ulong? checkpoint);
+    }
+}

--- a/Source/EventFlow.EventStores.EventStore/Subscriptions/StreamName.cs
+++ b/Source/EventFlow.EventStores.EventStore/Subscriptions/StreamName.cs
@@ -1,0 +1,46 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.EventStores.EventStore.Subscriptions
+{
+    public class StreamName
+    {
+        string Value { get; }
+
+        const string AllStreamName = "$all";
+
+        StreamName(string value) => Value = value;
+
+        public static StreamName AllStream => new StreamName(AllStreamName);
+
+        public static StreamName For<T>(string id) => new StreamName($"{typeof(T).Name}-{id}");
+
+        public static StreamName Custom(string streamName) => new StreamName(streamName);
+
+        public bool IsAllStream => Value.Equals(AllStreamName);
+
+        public override string ToString() => Value ?? "";
+
+        public static implicit operator string(StreamName self) => self.ToString();
+    }
+}


### PR DESCRIPTION
Adding UseEventStoreSubscriptions extension to help subscribe to stream  events based on a filter and then publish them to your internal microservices (pubsub)

Note that three (3) integration tests are failing due to EventStoreEventPersistence.LoadAllCommittedEvents fetching ALL events including "system events" which are prefixed with $ and fail when being deserialized.

I would like to have folks who use EventStoreDB to review this pull request and share their thoughts/feedback for improvements.