### PR TITLE
Add Previous Source Ids to Snapshot Metadata

### DIFF
--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
@@ -21,8 +21,10 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EventFlow.Core;
 using EventFlow.Snapshots;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Snapshots;
@@ -215,6 +217,7 @@ namespace EventFlow.TestHelpers.Suites
                     AggregateSequenceNumber = aggregateSequenceNumber,
                     SnapshotName = snapshotDefinition.Name,
                     SnapshotVersion = snapshotDefinition.Version,
+                    PreviousSourceIds = new List<ISourceId>()
                 };
 
             return SnapshotPersistence.SetSnapshotAsync(

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
+using EventFlow.Commands;
 using EventFlow.Core;
 using EventFlow.EventStores;
 using EventFlow.Snapshots;
@@ -86,6 +87,7 @@ namespace EventFlow.Tests.UnitTests.Snapshots
             // Assert
             Sut.Version.Should().Be(eventsInStore);
             Sut.SnapshotVersion.GetValueOrDefault().Should().Be(ThingyAggregate.SnapshotEveryVersion);
+            Sut.PreviousSourceIds.Should().NotBeEmpty();
         }
 
         [SetUp]
@@ -131,7 +133,8 @@ namespace EventFlow.Tests.UnitTests.Snapshots
                         thingySnapshot,
                         new SnapshotMetadata
                             {
-                                AggregateSequenceNumber = thingySnapshot.PingsReceived.Count
+                                AggregateSequenceNumber = thingySnapshot.PingsReceived.Count,
+                                PreviousSourceIds = new List<ISourceId>(){ new SourceId(CommandId.New.Value)}
                             }));
         }
 

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -35,6 +35,7 @@ namespace EventFlow.Aggregates
         IAggregateName Name { get; }
         int Version { get; }
         IEnumerable<IUncommittedEvent> UncommittedEvents { get; }
+        IEnumerable<ISourceId> PreviousSourceIds { get; }
         bool IsNew { get; }
 
         Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(IEventStore eventStore, ISnapshotStore snapshotStore, ISourceId sourceId, CancellationToken cancellationToken);

--- a/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Collections.Generic;
 using EventFlow.Core;
 
 namespace EventFlow.Snapshots
@@ -32,5 +33,7 @@ namespace EventFlow.Snapshots
         int AggregateSequenceNumber { get; }
         string AggregateId { get; }
         string AggregateName { get; }
+        IReadOnlyCollection<ISourceId> PreviousSourceIds { get;  }
+
     }
 }

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -70,7 +70,7 @@ namespace EventFlow.Snapshots
             await LoadSnapshotContainerAsync(snapshot, cancellationToken).ConfigureAwait(false);
 
             Version = snapshot.Metadata.AggregateSequenceNumber;
-
+            AddPreviousSourceIds(snapshot.Metadata.PreviousSourceIds);
             var domainEvents = await eventStore.LoadEventsAsync<TAggregate, TIdentity>(
                 Id,
                 Version + 1,
@@ -145,7 +145,8 @@ namespace EventFlow.Snapshots
                     AggregateId = Id.Value,
                     AggregateName = Name.Value,
                     AggregateSequenceNumber = Version,
-                };
+                    PreviousSourceIds = PreviousSourceIds.ToList()
+            };
 
             return Task.FromResult(snapshotMetadata);
         }

--- a/Source/EventFlow/Snapshots/SnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadata.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -31,6 +32,8 @@ namespace EventFlow.Snapshots
 {
     public class SnapshotMetadata : MetadataContainer, ISnapshotMetadata
     {
+        private static readonly IReadOnlyCollection<ISourceId> Empty = new List<ISourceId>();
+        private static readonly char[] SourceIdSeparators = {','};
         public SnapshotMetadata()
         {
         }
@@ -84,5 +87,24 @@ namespace EventFlow.Snapshots
             get { return GetMetadataValue(SnapshotMetadataKeys.SnapshotVersion, int.Parse); }
             set { Add(SnapshotMetadataKeys.SnapshotVersion, value.ToString(CultureInfo.InvariantCulture)); }
         }
+
+        [JsonIgnore]
+        public IReadOnlyCollection<ISourceId> PreviousSourceIds
+        {
+            get
+            {
+                return GetMetadataValue(SnapshotMetadataKeys.PreviousSourceIds, (json) =>
+                    string.IsNullOrWhiteSpace(json) ? 
+                        Empty : 
+                        json
+                            .Split(SourceIdSeparators, StringSplitOptions.RemoveEmptyEntries)
+                            .Select(sourceId => new SourceId(sourceId))
+                            .ToList().AsReadOnly());
+            }
+            set { Add(SnapshotMetadataKeys.PreviousSourceIds, string.Join(",", value.Select(x => x.Value)));}
+        }
+
+
+
     }
 }

--- a/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
@@ -30,5 +30,6 @@ namespace EventFlow.Snapshots
         public const string AggregateSequenceNumber = "aggregate_sequence_number";
         public const string SnapshotName = "snapshot_name";
         public const string SnapshotVersion = "snapshot_version";
+        public const string PreviousSourceIds = "previous_source_ids";
     }
 }


### PR DESCRIPTION
Fixes #799 

This allows the aggregate to correctly throw duplicate command exceptions on an aggregate loaded via snapshot