### PR TITLE
Add support for using a custom hangfire queue name

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,11 @@
-### New in 0.82 (not released yet)
+### New in 0.83 (not released yet)
+
+* New: Queue name used by HangfireJobScheduler can be overridden:
+  ```csharp
+  eventFlowOptions.UseHangfireJobScheduler(o => o.UseQueueName("myqueue"))
+  ```
+
+### New in 0.82.4659 (released 2021-06-17)
 
 * Fix: Source IDs are now added to snapshots
 * Fix: InMemoryReadStore will not break on unmodified update result

--- a/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
+++ b/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
@@ -48,5 +48,14 @@ namespace EventFlow.Hangfire.Extensions
                     sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
                 });
         }
+
+        public static IEventFlowOptions UseHangfireJobScheduler(
+            this IEventFlowOptions eventFlowOptions,
+            Action<IEventFlowHangfireOptions> configurationAction)
+        {
+            var options = eventFlowOptions.UseHangfireJobScheduler();
+            configurationAction(new EventFlowHangfireOptions(options));
+            return options;
+        }
     }
 }

--- a/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
+++ b/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
@@ -46,6 +46,7 @@ namespace EventFlow.Hangfire.Extensions
                     sr.Register<IHangfireJobRunner, HangfireJobRunner>();
                     sr.Register<IJobDisplayNameBuilder, JobDisplayNameBuilder>();
                     sr.Register<IBackgroundJobClient>(r => new BackgroundJobClient());
+                    sr.Register<IQueueNameProvider>(r => new QueueNameProvider(null));
                 });
         }
 

--- a/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Hangfire.Integration
+{
+    internal class EventFlowHangfireOptions : IEventFlowHangfireOptions
+    {
+        private readonly IEventFlowOptions _eventFlowOptions;
+
+        public EventFlowHangfireOptions(IEventFlowOptions eventFlowOptions)
+        {
+            _eventFlowOptions = eventFlowOptions;
+        }
+
+        public IEventFlowHangfireOptions UseQueueName(string queueName)
+        {
+            _eventFlowOptions.RegisterServices(sr => sr.Register<IQueueNameProvider>(r => new QueueNameProvider(queueName)));
+            return this;
+        }
+    }
+}

--- a/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
@@ -41,5 +41,10 @@ namespace EventFlow.Hangfire.Integration
         {
             return _jobRunner.ExecuteAsync(jobName, version, job, CancellationToken.None);
         }
+
+        public Task ExecuteAsync(string displayName, string jobName, int version, string job, string queueName)
+        {
+            return _jobRunner.ExecuteAsync(jobName, version, job, CancellationToken.None);
+        }
     }
 }

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
@@ -46,14 +46,14 @@ namespace EventFlow.Hangfire.Integration
             IJsonSerializer jsonSerializer,
             IBackgroundJobClient backgroundJobClient,
             IJobDefinitionService jobDefinitionService,
-            IQueueNameProvider queueNameProvider = null)
+            IQueueNameProvider queueNameProvider)
         {
             _log = log;
             _jobDisplayNameBuilder = jobDisplayNameBuilder;
             _jsonSerializer = jsonSerializer;
             _backgroundJobClient = backgroundJobClient;
             _jobDefinitionService = jobDefinitionService;
-            _queueName = queueNameProvider?.QueueName;
+            _queueName = queueNameProvider.QueueName;
         }
 
         public Task<IJobId> ScheduleNowAsync(IJob job, CancellationToken cancellationToken)

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
@@ -38,19 +38,22 @@ namespace EventFlow.Hangfire.Integration
         private readonly IJsonSerializer _jsonSerializer;
         private readonly ILog _log;
         private readonly IJobDisplayNameBuilder _jobDisplayNameBuilder;
+        private readonly string _queueName;
 
         public HangfireJobScheduler(
             ILog log,
             IJobDisplayNameBuilder jobDisplayNameBuilder,
             IJsonSerializer jsonSerializer,
             IBackgroundJobClient backgroundJobClient,
-            IJobDefinitionService jobDefinitionService)
+            IJobDefinitionService jobDefinitionService,
+            IQueueNameProvider queueNameProvider = null)
         {
             _log = log;
             _jobDisplayNameBuilder = jobDisplayNameBuilder;
             _jsonSerializer = jsonSerializer;
             _backgroundJobClient = backgroundJobClient;
             _jobDefinitionService = jobDefinitionService;
+            _queueName = queueNameProvider?.QueueName;
         }
 
         public Task<IJobId> ScheduleNowAsync(IJob job, CancellationToken cancellationToken)
@@ -58,7 +61,7 @@ namespace EventFlow.Hangfire.Integration
             return ScheduleAsync(
                 job,
                 cancellationToken,
-                (c, d, n, j) => _backgroundJobClient.Enqueue<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j)));
+                (c, d, n, j) => _backgroundJobClient.Enqueue<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j, _queueName)));
         }
 
         public Task<IJobId> ScheduleAsync(IJob job, DateTimeOffset runAt, CancellationToken cancellationToken)
@@ -66,7 +69,7 @@ namespace EventFlow.Hangfire.Integration
             return ScheduleAsync(
                 job,
                 cancellationToken,
-                (c, d, n, j) => _backgroundJobClient.Schedule<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j), runAt));
+                (c, d, n, j) => _backgroundJobClient.Schedule<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j, _queueName), runAt));
         }
 
         public Task<IJobId> ScheduleAsync(IJob job, TimeSpan delay, CancellationToken cancellationToken)
@@ -74,7 +77,7 @@ namespace EventFlow.Hangfire.Integration
             return ScheduleAsync(
                 job,
                 cancellationToken,
-                (c, d, n, j) => _backgroundJobClient.Schedule<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j), delay));
+                (c, d, n, j) => _backgroundJobClient.Schedule<IHangfireJobRunner>(r => r.ExecuteAsync(n, d.Name, d.Version, j, _queueName), delay));
         }
 
         private async Task<IJobId> ScheduleAsync(

--- a/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Hangfire.Integration
+{
+    public interface IEventFlowHangfireOptions
+    {
+        IEventFlowHangfireOptions UseQueueName(string queueName);
+    }
+}

--- a/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
@@ -30,5 +30,8 @@ namespace EventFlow.Hangfire.Integration
     {
         [DisplayName("{0}")]
         Task ExecuteAsync(string displayName, string jobName, int version, string job);
+
+        [DisplayName("{0}"), UseQueueFromParameter(4)]
+        Task ExecuteAsync(string displayName, string jobName, int version, string job, string queueName);
     }
 }

--- a/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Hangfire.Integration
+{
+    public interface IQueueNameProvider
+    {
+        string QueueName { get; }
+    }
+}

--- a/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Hangfire.Integration
+{
+    internal class QueueNameProvider : IQueueNameProvider
+    {
+        public string QueueName { get; }
+
+        public QueueNameProvider(string queueName)
+        {
+            QueueName = queueName;
+        }
+    }
+}

--- a/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
+++ b/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
@@ -1,4 +1,27 @@
-﻿using Hangfire.Common;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Hangfire.Common;
 using Hangfire.States;
 using System;
 using System.Collections.Generic;

--- a/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
+++ b/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
@@ -1,0 +1,38 @@
+﻿using Hangfire.Common;
+using Hangfire.States;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Hangfire.Integration
+{
+    internal class UseQueueFromParameterAttribute : JobFilterAttribute, IElectStateFilter
+    {
+        public UseQueueFromParameterAttribute(int parameterIndex)
+        {
+            if (parameterIndex < 0)
+                throw new InvalidOperationException("Invalid queue name parameter index");
+
+            ParameterIndex = parameterIndex;
+        }
+
+        public int ParameterIndex { get; }
+
+        public void OnStateElection(ElectStateContext context)
+        {
+            var enqueuedState = context.CandidateState as EnqueuedState;
+            if (enqueuedState != null)
+            {
+                if (ParameterIndex >= context.BackgroundJob.Job.Args.Count)
+                    throw new InvalidOperationException("Invalid queue name parameter index");
+
+                var queueName = context.BackgroundJob.Job.Args[ParameterIndex] as string;
+
+                if (queueName != null)
+                    enqueuedState.Queue = queueName;
+            }
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
   - ps: '[Environment]::SetEnvironmentVariable("LCOW_SUPPORTED", "1", "Machine")'
   - ps: Restart-Service docker
 
-version: 0.82.{build}
+version: 0.83.{build}
 
 skip_tags: true
 


### PR DESCRIPTION
I've adapted the solution from rikbosch here: https://discuss.hangfire.io/t/one-queue-for-the-whole-farm-and-one-queue-by-server/490/4

The main requirement for allowing this is that we have shared development databases used by many developers. Allowing a developer to use a custom queue name allows them to ensure that they are going to handle the events / jobs they raise, so it can be properly debugged. Without it there's no guarantee where it will run if multiple developers are debugging at the same time.

Usage is:
```csharp
eventFlowOptions.UseHangfireJobScheduler(o => o.UseQueueName("myqueue"))
```