### PR TITLE
New feature: Entity Framework - Eager loading of related data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,18 @@
 
 * Fix: Source IDs are now added to snapshots
 * Fix: InMemoryReadStore will not break on unmodified update result
+* New: added extension methods to the `EventFlow.EntityFramework` package that allow
+  us to configure [eager loading of related data](https://docs.microsoft.com/en-us/ef/core/querying/related-data/eager). Example usage:
+  ```csharp
+  public static IEventFlowOptions Configure(this IEventFlowOptions options)
+  {
+    return options
+      .UseEntityFrameworkReadModel<MyEntity, MyDbContext>(
+        cfg => cfg.Include(x => x.SomeProperty)
+                  .ThenInclude(y => y.SomeOtherProperty)
+      );
+  }
+  ```
 
 ### New in 0.81.4483 (released 2020-12-14)
 

--- a/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
+++ b/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
@@ -23,6 +23,8 @@
 
 using EventFlow.EntityFramework.Extensions;
 using EventFlow.EntityFramework.Tests.Model;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Queries;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.ReadModels;
 using EventFlow.Extensions;
 using EventFlow.TestHelpers.Aggregates.Entities;
 
@@ -52,6 +54,13 @@ namespace EventFlow.EntityFramework.Tests
                     typeof(EfThingyGetQueryHandler),
                     typeof(EfThingyGetVersionQueryHandler),
                     typeof(EfThingyGetMessagesQueryHandler));
+        }
+
+        public static IEventFlowOptions ConfigureForReadStoreIncludeTest(this IEventFlowOptions options)
+        {
+            return options
+                .UseEntityFrameworkReadModel<PersonReadModelEntity, TestDbContext>(cfg => cfg.Include(x => x.Addresses))
+                .AddQueryHandlers(typeof(PersonGetQueryHandler));
         }
     }
 }

--- a/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using EventFlow.EntityFramework.Extensions;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.ReadModels;
 using Microsoft.EntityFrameworkCore;
 
 namespace EventFlow.EntityFramework.Tests.Model
@@ -35,6 +36,10 @@ namespace EventFlow.EntityFramework.Tests.Model
         public DbSet<ThingyReadModelEntity> Thingys { get; set; }
         public DbSet<ThingyMessageReadModelEntity> ThingyMessages { get; set; }
 
+        // Include tests
+        public DbSet<PersonReadModelEntity> Persons { get; set; }
+        public DbSet<AddressReadModelEntity> Addresses { get; set; }
+        
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder
@@ -48,6 +53,14 @@ namespace EventFlow.EntityFramework.Tests.Model
             modelBuilder.Entity<ThingyReadModelEntity>()
                 .Property(e => e.AggregateId)
                 .ValueGeneratedOnAdd();
+
+            modelBuilder.Entity<PersonReadModelEntity>()
+                .Property(e => e.AggregateId)
+                .ValueGeneratedOnAdd();
+
+            modelBuilder.Entity<AddressReadModelEntity>()
+                .Property(e => e.AddressId)
+                .ValueGeneratedNever();
         }
     }
 }

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
@@ -1,0 +1,98 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Configuration;
+using EventFlow.EntityFramework.Extensions;
+using EventFlow.EntityFramework.Tests.Model;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Commands;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Queries;
+using EventFlow.Extensions;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.MsSql;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.EntityFramework.Tests.MsSql
+{
+    [Category(Categories.Integration)]
+    public class EfMsSqlReadStoreIncludeTests : IntegrationTest
+    {
+        private IMsSqlDatabase _testDatabase;
+
+        protected override IRootResolver CreateRootResolver(IEventFlowOptions eventFlowOptions)
+        {
+            _testDatabase = MsSqlHelpz.CreateDatabase("eventflow");
+
+            return eventFlowOptions
+                .RegisterServices(sr => sr.Register(c => _testDatabase.ConnectionString))
+                .ConfigureEntityFramework(EntityFrameworkConfiguration.New)
+                .AddDbContextProvider<TestDbContext, MsSqlDbContextProvider>()
+                .ConfigureForReadStoreIncludeTest()
+                .AddDefaults(typeof(EfMsSqlReadStoreIncludeTests).Assembly)
+                .CreateResolver();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testDatabase.DisposeSafe("Failed to delete database");
+        }
+
+        [Test]
+        public async Task ReadModelContainsPersonNameAfterCreation()
+        {
+            // Arrange
+            var id = PersonId.New;
+            
+            // Act
+            await CommandBus
+                .PublishAsync(new CreatePersonCommand(id, "Bob"), CancellationToken.None)
+                .ConfigureAwait(false);
+            
+            var readModel = await QueryProcessor
+                .ProcessAsync(new PersonGetQuery(id), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert
+            readModel.Should().NotBeNull();
+            readModel.Name.Should().Be("Bob");
+            readModel.Addresses.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task ReadModelContainsPersonAddressesAfterAdd()
+        {
+            // Arrange
+            var id = PersonId.New;
+            await CommandBus
+                .PublishAsync(new CreatePersonCommand(id, "Bob"), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Act
+            var address1 = new Address(AddressId.New, "Smith street 4.", "1234", "New York", "US");
+            await CommandBus
+                .PublishAsync(new AddAddressCommand(id, 
+                        address1), 
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var address2 = new Address(AddressId.New, "Musterstraﬂe 42.", "6541", "Berlin", "DE");
+            await CommandBus
+                .PublishAsync(new AddAddressCommand(id, 
+                        address2), 
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var readModel = await QueryProcessor
+                .ProcessAsync(new PersonGetQuery(id), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert
+            readModel.Should().NotBeNull();
+            readModel.NumberOfAddresses.Should().Be(2);
+            readModel.Addresses.Should().HaveCount(2);
+            readModel.Addresses.Should().ContainEquivalentOf(address1);
+            readModel.Addresses.Should().ContainEquivalentOf(address2);
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
@@ -1,3 +1,26 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Configuration;

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Entities;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Entities;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
 {

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
@@ -1,0 +1,20 @@
+﻿using EventFlow.Entities;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
+{
+    public class Address : Entity<AddressId>
+    {
+        public string Street { get; set; }
+        public string PostalCode { get; set; }
+        public string City { get; set; }
+        public string Country { get; set; }
+
+        public Address(AddressId id, string street, string postalCode, string city, string country) : base(id)
+        {
+            Street = street;
+            PostalCode = postalCode;
+            City = city;
+            Country = country;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Core;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Core;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
 {

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
@@ -1,0 +1,11 @@
+﻿using EventFlow.Core;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
+{
+    public class AddressId : Identity<AddressId>
+    {
+        public AddressId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Commands;
 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Commands
+{
+    public class AddAddressCommand : Command<PersonAggregate, PersonId>
+    {
+        public Address PersonAddress { get; }
+
+        public AddAddressCommand(PersonId aggregateId, Address personAddress) : base(aggregateId)
+        {
+            PersonAddress = personAddress;
+        }
+    }
+
+    public class AddAddressCommandHandler : CommandHandler<PersonAggregate, PersonId, AddAddressCommand>
+    {
+        public override Task ExecuteAsync(PersonAggregate aggregate, AddAddressCommand command, CancellationToken cancellationToken)
+        {
+            aggregate.AddAddress(command.PersonAddress);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Commands;
 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Commands
+{
+    public class CreatePersonCommand : Command<PersonAggregate,PersonId>
+    {
+        public string Name { get; }
+
+        public CreatePersonCommand(PersonId aggregateId, string name)
+            :base(aggregateId)
+        {
+            Name = name;
+        }
+    }
+
+    public class CreatePersonCommandHandler : CommandHandler<PersonAggregate, PersonId, CreatePersonCommand>
+    {
+        public override Task ExecuteAsync(PersonAggregate aggregate, CreatePersonCommand command, CancellationToken cancellationToken)
+        {
+            aggregate.Create(command.Name);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
@@ -1,0 +1,14 @@
+﻿using EventFlow.Aggregates;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events
+{
+    public class AddressAddedEvent : AggregateEvent<PersonAggregate, PersonId>
+    {
+        public Address Address { get; set; }
+
+        public AddressAddedEvent(Address address)
+        {
+            Address = address;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events
 {

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events
 {

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
@@ -1,0 +1,14 @@
+﻿using EventFlow.Aggregates;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events
+{
+    public class PersonCreatedEvent : AggregateEvent<PersonAggregate, PersonId>
+    {
+        public string Name { get; set; }
+
+        public PersonCreatedEvent(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
 using EventFlow.Entities;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using EventFlow.Entities;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
+{
+    public class Person : Entity<PersonId>
+    {
+        public string Name { get; }
+        public ICollection<Address> Addresses { get; }
+        public int NumberOfAddresses { get; }
+
+        public Person(PersonId id, string name, ICollection<Address> addresses, int numberOfAddresses) : base(id)
+        {
+            Name = name;
+            Addresses = addresses;
+            NumberOfAddresses = numberOfAddresses;
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
@@ -1,0 +1,37 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
+{
+    [AggregateName("Person")]
+    public class PersonAggregate : AggregateRoot<PersonAggregate, PersonId>,
+        IEmit<PersonCreatedEvent>,
+        IEmit<AddressAddedEvent>
+    {
+        public PersonAggregate(PersonId id) : base(id)
+        {
+        }
+
+        public void Create(string name)
+        {
+            Emit(new PersonCreatedEvent(name));
+        }
+
+        public void AddAddress(Address address)
+        {
+            Emit(new AddressAddedEvent(address));
+        }
+
+        void IEmit<PersonCreatedEvent>.Apply(PersonCreatedEvent aggregateEvent)
+        {
+            // save name into field for later usage
+            // ..
+        }
+
+        void IEmit<AddressAddedEvent>.Apply(AddressAddedEvent aggregateEvent)
+        {
+            // save address into field for later usage
+            // ..
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Core;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Core;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
 {

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
@@ -1,0 +1,11 @@
+﻿using EventFlow.Core;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests
+{
+    public class PersonId : Identity<PersonId>
+    {
+        public PersonId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.EntityFramework.Tests.Model;
 using EventFlow.Queries;

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.EntityFramework.Tests.Model;
+using EventFlow.Queries;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Queries
+{
+    public class PersonGetQuery : IQuery<Person>
+    {
+        public PersonId PersonId { get; }
+
+        public PersonGetQuery(PersonId personId)
+        {
+            PersonId = personId;
+        }
+    }
+
+    public class PersonGetQueryHandler : IQueryHandler<PersonGetQuery, Person>
+    {
+        private readonly IDbContextProvider<TestDbContext> _dbContextProvider;
+
+        public PersonGetQueryHandler(IDbContextProvider<TestDbContext> dbContextProvider)
+        {
+            _dbContextProvider = dbContextProvider;
+        }
+
+        public async Task<Person> ExecuteQueryAsync(PersonGetQuery query, CancellationToken cancellationToken)
+        {
+            await using var context = _dbContextProvider.CreateContext();
+            var entity = await context.Persons
+                .Include(x => x.Addresses)
+                .SingleOrDefaultAsync(x => x.AggregateId == query.PersonId.Value, cancellationToken)
+                .ConfigureAwait(false);
+            return entity?.ToPerson();
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
@@ -1,4 +1,27 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.ReadModels

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.ReadModels
+{
+    public class AddressReadModelEntity
+    {
+        [Key]
+        [StringLength(64)]
+        public string AddressId { get; set; }
+
+        [StringLength(64)]
+        public string PersonId { get; set; }
+
+        [ForeignKey(nameof(PersonId))]
+        public virtual PersonReadModelEntity Person { get; set; }
+
+        public string Street { get; set; }
+
+        public string PostalCode { get; set; }
+
+        public string City { get; set; }
+
+        public string Country { get; set; }
+
+        public Address ToAddress() => new Address(IncludeTests.AddressId.With(AddressId), Street, PostalCode, City, Country);
+    }
+}

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using EventFlow.Aggregates;

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using EventFlow.Aggregates;
+using EventFlow.EntityFramework.Tests.MsSql.IncludeTests.Events;
+using EventFlow.ReadStores;
+
+namespace EventFlow.EntityFramework.Tests.MsSql.IncludeTests.ReadModels
+{
+    public class PersonReadModelEntity : IReadModel,
+        IAmReadModelFor<PersonAggregate, PersonId, PersonCreatedEvent>,
+        IAmReadModelFor<PersonAggregate, PersonId, AddressAddedEvent>
+    {
+        [Key] 
+        [StringLength(64)]
+        public string AggregateId { get; set; }
+
+        public string Name { get; set; }
+
+        public int NumberOfAddresses { get; set; }
+
+        public virtual ICollection<AddressReadModelEntity> Addresses { get; set; } = new List<AddressReadModelEntity>();
+
+        public void Apply(IReadModelContext context,
+            IDomainEvent<PersonAggregate, PersonId, PersonCreatedEvent> domainEvent)
+        {
+            Name = domainEvent.AggregateEvent.Name;
+        }
+
+        public void Apply(IReadModelContext context,
+            IDomainEvent<PersonAggregate, PersonId, AddressAddedEvent> domainEvent)
+        {
+            var address = domainEvent.AggregateEvent.Address;
+            Addresses.Add(new AddressReadModelEntity
+            {
+                AddressId = address.Id.Value,
+                PersonId = domainEvent.AggregateIdentity.Value,
+                Street = address.Street,
+                City = address.City,
+                PostalCode = address.PostalCode,
+                Country = address.Country
+            });
+
+            NumberOfAddresses = Addresses.Count;
+        }
+
+        public Person ToPerson() =>
+            new Person(
+                PersonId.With(AggregateId),
+                Name, 
+                Addresses?.Select(x => x.ToAddress()).ToList(),
+                NumberOfAddresses);
+    }
+}

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System.Linq;
+using EventFlow.EntityFramework.ReadStores.Configuration;
+using EventFlow.ReadStores;
+
+namespace EventFlow.EntityFramework
+{
+    public sealed class EntityFrameworkReadModelConfiguration<TReadModel> : IApplyQueryableConfiguration<TReadModel>
+        where TReadModel : class, IReadModel, new()
+    {
+        IQueryable<TReadModel>
+            IApplyQueryableConfiguration<TReadModel>.Apply(IQueryable<TReadModel> queryable) =>
+            queryable;
+    }
+}

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System.Linq;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
 using EventFlow.EntityFramework.ReadStores.Configuration;
 using EventFlow.ReadStores;
 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using EventFlow.EntityFramework.ReadStores.Configuration;

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using EventFlow.EntityFramework.ReadStores.Configuration;
+using EventFlow.EntityFramework.ReadStores.Configuration.Includes;
+using EventFlow.ReadStores;
+
+namespace EventFlow.EntityFramework
+{
+    /// <summary>
+    /// Extensions methods to configure the ReadModel
+    /// </summary>
+    public static class EntityFrameworkReadModelConfigurationExtensions
+    {
+        /// <inheritdoc cref="Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.Include{TReadModel,TProperty}(System.Linq.IQueryable{TReadModel},Expression{Func{TReadModel, TProperty}})"/>
+        public static IncludeExpression<TReadModel, TProperty>
+            Include<TReadModel, TProperty>(
+                this IApplyQueryableConfiguration<TReadModel> source,
+                Expression<Func<TReadModel, TProperty>> navigationPropertyPath)
+            where TReadModel : class, IReadModel, new()
+        {
+            if (navigationPropertyPath == null)
+            {
+                throw new ArgumentNullException(nameof(navigationPropertyPath));
+            }
+
+            return new IncludeExpression<TReadModel, TProperty>(
+                source,
+                navigationPropertyPath);
+        }
+
+        /// <inheritdoc cref="Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.Include{TReadModel}(System.Linq.IQueryable{TReadModel},string)"/>
+        public static IncludeString<TReadModel>
+            Include<TReadModel>(
+                this IApplyQueryableConfiguration<TReadModel> source,
+                string navigationPropertyPath)
+            where TReadModel : class, IReadModel, new()
+        {
+            if (navigationPropertyPath == null)
+            {
+                throw new ArgumentNullException(nameof(navigationPropertyPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(navigationPropertyPath))
+            {
+                throw new ArgumentException("Must not be null or empty", nameof(navigationPropertyPath));
+            }
+
+            return new IncludeString<TReadModel>(
+                source, 
+                navigationPropertyPath);
+        }
+
+        /// <inheritdoc cref="Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ThenInclude{TReadModel,TPreviousProperty,TProperty}(Microsoft.EntityFrameworkCore.Query.IIncludableQueryable{TReadModel,TPreviousProperty},Expression{Func{TPreviousProperty, TProperty}})"/>
+        public static ThenIncludeExpression<TEntity, TPreviousProperty, TProperty>
+            ThenInclude<TEntity, TPreviousProperty, TProperty>(
+                this IApplyQueryableIncludeConfiguration<TEntity, TPreviousProperty> source,
+                Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            where TEntity : class, IReadModel, new()
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (navigationPropertyPath == null)
+            {
+                throw new ArgumentNullException(nameof(navigationPropertyPath));
+            }
+
+            return new ThenIncludeExpression<TEntity, TPreviousProperty, TProperty>(
+                source,
+                navigationPropertyPath);
+        }
+
+        /// <inheritdoc cref="Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ThenInclude{TReadModel,TPreviousProperty,TProperty}(Microsoft.EntityFrameworkCore.Query.IIncludableQueryable{TReadModel,IEnumerable{TPreviousProperty}},Expression{Func{TPreviousProperty, TProperty}})"/>
+        public static ThenIncludeEnumerableExpression<TEntity, TPreviousProperty, TProperty>
+            ThenInclude<TEntity, TPreviousProperty, TProperty>(
+                this IApplyQueryableIncludeConfiguration<TEntity, IEnumerable<TPreviousProperty>> source,
+                Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            where TEntity : class, IReadModel, new()
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (navigationPropertyPath == null)
+            {
+                throw new ArgumentNullException(nameof(navigationPropertyPath));
+            }
+
+            return new ThenIncludeEnumerableExpression<TEntity, TPreviousProperty, TProperty>(
+                source,
+                navigationPropertyPath);
+        }
+    }
+}

--- a/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
@@ -25,6 +25,8 @@ using System;
 using EventFlow.Configuration;
 using EventFlow.EntityFramework.EventStores;
 using EventFlow.EntityFramework.ReadStores;
+using EventFlow.EntityFramework.ReadStores.Configuration;
+using EventFlow.EntityFramework.ReadStores.Configuration.Includes;
 using EventFlow.EntityFramework.SnapshotStores;
 using EventFlow.Extensions;
 using EventFlow.ReadStores;
@@ -68,10 +70,79 @@ namespace EventFlow.EntityFramework.Extensions
                 {
                     f.Register<IEntityFrameworkReadModelStore<TReadModel>,
                         EntityFrameworkReadModelStore<TReadModel, TDbContext>>();
+                    f.Register<IApplyQueryableConfiguration<TReadModel>>(_ => 
+                        new EntityFrameworkReadModelConfiguration<TReadModel>(), Lifetime.Singleton);
                     f.Register<IReadModelStore<TReadModel>>(r =>
                         r.Resolver.Resolve<IEntityFrameworkReadModelStore<TReadModel>>());
                 })
                 .UseReadStoreFor<IEntityFrameworkReadModelStore<TReadModel>, TReadModel>();
+        }
+
+        /// <summary>
+        /// Configures the read model. Can be used for eager loading of related data by appending .Include(..) / .ThenInclude(..) statements.
+        /// </summary>
+        /// <typeparam name="TReadModel">The read model's entity type</typeparam>
+        /// <typeparam name="TDbContext">The database context type</typeparam>
+        /// <param name="eventFlowOptions"><inheritdoc cref="IEventFlowOptions"/></param>
+        /// <param name="configure">Function to configure eager loading of related data by appending .Include(..) / .ThenInclude(..) statements.</param>
+        /// <remarks>Avoid navigation properties if you create read models for both, the parent entity and the child entity. Otherwise there is a risk of a ordering problem when saving aggregates and updating read modules independently (FOREIGN-KEY constraint)</remarks>
+        public static IEventFlowOptions UseEntityFrameworkReadModel<TReadModel, TDbContext>(
+            this IEventFlowOptions eventFlowOptions,
+            Func<EntityFrameworkReadModelConfiguration<TReadModel>,IApplyQueryableConfiguration<TReadModel>> configure)
+            where TDbContext : DbContext
+            where TReadModel : class, IReadModel, new()
+        {
+            return eventFlowOptions
+                .RegisterServices(f =>
+                {
+                    f.Register<IEntityFrameworkReadModelStore<TReadModel>,
+                        EntityFrameworkReadModelStore<TReadModel, TDbContext>>();
+                    f.Register(_ =>
+                    {
+                        var readModelConfig = new EntityFrameworkReadModelConfiguration<TReadModel>();
+                        return configure != null
+                            ? configure(readModelConfig)
+                            : readModelConfig;
+
+                    }, Lifetime.Singleton);
+                    f.Register<IReadModelStore<TReadModel>>(r =>
+                        r.Resolver.Resolve<IEntityFrameworkReadModelStore<TReadModel>>());
+                })
+                .UseReadStoreFor<IEntityFrameworkReadModelStore<TReadModel>, TReadModel>();
+        }
+
+        /// <summary>
+        /// Configures the read model. Can be used for eager loading of related data by appending .Include(..) / .ThenInclude(..) statements.
+        /// </summary>
+        /// <typeparam name="TReadModel">The read model's entity type</typeparam>
+        /// <typeparam name="TDbContext">The database context type</typeparam>
+        /// <typeparam name="TReadModelLocator">The read model locator type</typeparam>
+        /// <param name="eventFlowOptions"><inheritdoc cref="IEventFlowOptions"/></param>
+        /// <param name="configure">Function to configure eager loading of related data by appending .Include(..) / .ThenInclude(..) statements.</param>
+        /// <remarks>Avoid navigation properties if you create read models for both, the parent entity and the child entity. Otherwise there is a risk of a ordering problem when saving aggregates and updating read modules independently (FOREIGN-KEY constraint)</remarks>
+        public static IEventFlowOptions UseEntityFrameworkReadModel<TReadModel, TDbContext, TReadModelLocator>(
+            this IEventFlowOptions eventFlowOptions,
+            Func<EntityFrameworkReadModelConfiguration<TReadModel>,IApplyQueryableConfiguration<TReadModel>> configure)
+            where TDbContext : DbContext
+            where TReadModel : class, IReadModel, new()
+            where TReadModelLocator : IReadModelLocator
+        {
+            return eventFlowOptions
+                .RegisterServices(f =>
+                {
+                    f.Register<IEntityFrameworkReadModelStore<TReadModel>,
+                        EntityFrameworkReadModelStore<TReadModel, TDbContext>>();
+                    f.Register(_ =>
+                    {
+                        var readModelConfig = new EntityFrameworkReadModelConfiguration<TReadModel>();
+                        return configure != null
+                            ? configure(readModelConfig)
+                            : readModelConfig;
+                    }, Lifetime.Singleton);
+                    f.Register<IReadModelStore<TReadModel>>(r =>
+                        r.Resolver.Resolve<IEntityFrameworkReadModelStore<TReadModel>>());
+                })
+                .UseReadStoreFor<IEntityFrameworkReadModelStore<TReadModel>, TReadModel, TReadModelLocator>();
         }
 
         public static IEventFlowOptions UseEntityFrameworkReadModel<TReadModel, TDbContext, TReadModelLocator>(
@@ -85,6 +156,8 @@ namespace EventFlow.EntityFramework.Extensions
                 {
                     f.Register<IEntityFrameworkReadModelStore<TReadModel>,
                         EntityFrameworkReadModelStore<TReadModel, TDbContext>>();
+                    f.Register<IApplyQueryableConfiguration<TReadModel>>(_ => 
+                        new EntityFrameworkReadModelConfiguration<TReadModel>(), Lifetime.Singleton);
                     f.Register<IReadModelStore<TReadModel>>(r =>
                         r.Resolver.Resolve<IEntityFrameworkReadModelStore<TReadModel>>());
                 })

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System.Linq;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
 using EventFlow.ReadStores;
 
 namespace EventFlow.EntityFramework.ReadStores.Configuration

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using EventFlow.ReadStores;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration
+{
+    /// <summary>
+    /// Configures an IQueryable
+    /// </summary>
+    /// <typeparam name="TReadModel">Entity type</typeparam>
+    public interface IApplyQueryableConfiguration<TReadModel>
+        where TReadModel : class, IReadModel, new()
+    {
+        /// <summary>
+        /// Applies the expression to the IQueryable
+        /// </summary>
+        /// <param name="queryable">Source</param>
+        /// <returns>The applied IQueryable</returns>
+        IQueryable<TReadModel> Apply(IQueryable<TReadModel> queryable);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System.Linq;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
 using EventFlow.ReadStores;
 using Microsoft.EntityFrameworkCore.Query;
 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using EventFlow.ReadStores;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration
+{
+    /// <summary>
+    /// Configures an IQueryable
+    /// </summary>
+    /// <typeparam name="TReadModel">Entity type</typeparam>
+    /// <typeparam name="TProperty">Property type</typeparam>
+    public interface IApplyQueryableIncludeConfiguration<TReadModel, out TProperty>
+        : IApplyQueryableConfiguration<TReadModel>
+        where TReadModel : class, IReadModel, new()
+    {
+        /// <summary>
+        /// Applies the include expression to the IQueryable
+        /// </summary>
+        /// <param name="queryable">Source</param>
+        /// <returns>An IIncludableQueryable</returns>
+        new IIncludableQueryable<TReadModel, TProperty> Apply(IQueryable<TReadModel> queryable);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using EventFlow.ReadStores;

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using EventFlow.ReadStores;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration.Includes
+{
+    public sealed class IncludeExpression<TReadModel, TProperty>
+        : IApplyQueryableIncludeConfiguration<TReadModel, TProperty>
+        where TReadModel : class, IReadModel, new()
+    {
+        private readonly IApplyQueryableConfiguration<TReadModel> _source;
+        private readonly Expression<Func<TReadModel, TProperty>> _navigationPropertyPath;
+
+        internal IncludeExpression(
+            IApplyQueryableConfiguration<TReadModel> source,
+            Expression<Func<TReadModel, TProperty>> navigationPropertyPath)
+        {
+            _source = source;
+            _navigationPropertyPath = navigationPropertyPath;
+        }
+
+        IQueryable<TReadModel>
+            IApplyQueryableConfiguration<TReadModel>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        IIncludableQueryable<TReadModel, TProperty>
+            IApplyQueryableIncludeConfiguration<TReadModel, TProperty>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        private IIncludableQueryable<TReadModel, TProperty> ApplyInternal(IQueryable<TReadModel> queryable) =>
+            _source.Apply(queryable).Include(_navigationPropertyPath);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
@@ -1,4 +1,27 @@
-﻿using System.Linq;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
 using EventFlow.ReadStores;
 using Microsoft.EntityFrameworkCore;
 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+using EventFlow.ReadStores;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration.Includes
+{
+    public sealed class IncludeString<TReadModel>
+        : IApplyQueryableConfiguration<TReadModel>
+        where TReadModel : class, IReadModel, new()
+    {
+        private readonly IApplyQueryableConfiguration<TReadModel> _source;
+        private readonly string _navigationPropertyPath;
+
+        internal IncludeString(
+            IApplyQueryableConfiguration<TReadModel> source,
+            string navigationPropertyPath)
+        {
+            _source = source;
+            _navigationPropertyPath = navigationPropertyPath;
+        }
+
+        IQueryable<TReadModel> IApplyQueryableConfiguration<TReadModel>.Apply(
+            IQueryable<TReadModel> queryable) =>
+            _source.Apply(queryable).Include(_navigationPropertyPath);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using EventFlow.ReadStores;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration.Includes
+{
+    public sealed class ThenIncludeEnumerableExpression<TReadModel, TPreviousProperty, TProperty>
+        : IApplyQueryableIncludeConfiguration<TReadModel, TProperty>
+        where TReadModel : class, IReadModel, new()
+    {
+        private readonly IApplyQueryableIncludeConfiguration<TReadModel, IEnumerable<TPreviousProperty>> _source;
+        private readonly Expression<Func<TPreviousProperty, TProperty>> _navigationPropertyPath;
+
+        public ThenIncludeEnumerableExpression(
+            IApplyQueryableIncludeConfiguration<TReadModel, IEnumerable<TPreviousProperty>> source,
+            Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+        {
+            _source = source;
+            _navigationPropertyPath = navigationPropertyPath;
+        }
+
+        IQueryable<TReadModel>
+            IApplyQueryableConfiguration<TReadModel>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        IIncludableQueryable<TReadModel, TProperty>
+            IApplyQueryableIncludeConfiguration<TReadModel, TProperty>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        private IIncludableQueryable<TReadModel, TProperty> ApplyInternal(IQueryable<TReadModel> queryable) =>
+            _source
+                .Apply(queryable)
+                .ThenInclude(_navigationPropertyPath);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using EventFlow.ReadStores;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace EventFlow.EntityFramework.ReadStores.Configuration.Includes
+{
+    public sealed class ThenIncludeExpression<TReadModel, TPreviousProperty, TProperty>
+        : IApplyQueryableIncludeConfiguration<TReadModel, TProperty>
+        where TReadModel : class, IReadModel, new()
+    {
+        private readonly IApplyQueryableIncludeConfiguration<TReadModel, TPreviousProperty> _source;
+        private readonly Expression<Func<TPreviousProperty, TProperty>> _navigationPropertyPath;
+
+        internal ThenIncludeExpression(
+            IApplyQueryableIncludeConfiguration<TReadModel, TPreviousProperty> source,
+            Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+        {
+            _source = source;
+            _navigationPropertyPath = navigationPropertyPath;
+        }
+
+        IQueryable<TReadModel>
+            IApplyQueryableConfiguration<TReadModel>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        IIncludableQueryable<TReadModel, TProperty>
+            IApplyQueryableIncludeConfiguration<TReadModel, TProperty>.Apply(
+                IQueryable<TReadModel> queryable) => ApplyInternal(queryable);
+
+        private IIncludableQueryable<TReadModel, TProperty> ApplyInternal(IQueryable<TReadModel> queryable) =>
+            _source
+                .Apply(queryable)
+                .ThenInclude(_navigationPropertyPath);
+    }
+}

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2020 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using EventFlow.ReadStores;


### PR DESCRIPTION
Added extensions methods to configure eager loading of related data by appending `.Include(..)` / `.ThenInclude(..)` statements.
(see Microsoft documentation https://docs.microsoft.com/en-us/ef/core/querying/related-data/eager.)

The Entity Framework adds FOREIGN-KEY constrains when working with navigation properties. This can lead to ordering problems when saving the read models within a single command. The problem is, that read models are processed separately - each using its own `DbContext` instance. If there is a relation between a _parent_ and its _child_ object, the _parent_ MUST be saved first. This cannot be enforced when a single aggregate update results in more than one read model updates.

The usage is pretty simple:

```c#
 public static IEventFlowOptions Configure(this IEventFlowOptions options)
 {
    return options
        .UseEntityFrameworkReadModel<MyEntity, MyDbContext>(
            cfg => cfg.Include(x => x.SomeProperty).ThenInclude(y => y.SomeOtherProperty)
        );
}
``` 