### PR TITLE
Allow the use of explicitly implemented interfaces in the read model

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 * Fix: Source IDs are now added to snapshots
 * Fix: InMemoryReadStore will not break on unmodified update result
+* Fix: Allow the use of explicitly implemented interfaces in the read model
 
 ### New in 0.81.4483 (released 2020-12-14)
 


### PR DESCRIPTION
If there is no public 'Apply' method (with the expected method parameters), the algorithm will check whether the read model implements either IAmReadModelFor or IAmAsyncReadModelFor. If this is the case, the 'Apply' method of the interface type is called instead.

Fixes #803 