### PR TITLE
Do not enforce previous source IDs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
   ```csharp
   eventFlowOptions.UseHangfireJobScheduler(o => o.UseQueueName("myqueue"))
   ```
+* Fixed: Do not throw `MetadataKeyNotFoundException` if there is no meta data on
+  `previous_source_ids` in snapshots
 
 ### New in 0.82.4684 (released 2021-08-31)
 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
@@ -81,5 +81,18 @@ namespace EventFlow.Tests.UnitTests.Snapshots
             deserializedSnapshotMetadata.SnapshotName.Should().Be("thingy");
             deserializedSnapshotMetadata.SnapshotVersion.Should().Be(84);
         }
+
+        [Test]
+        public void PreviousSourceIdsIsAllowedToBeEmpty()
+        {
+            // Arrange
+            var snapshotMetadata = new SnapshotMetadata();
+
+            // Act
+            var previousSourceIds = snapshotMetadata.PreviousSourceIds;
+
+            // Assert
+            previousSourceIds.Should().BeEmpty();
+        }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
@@ -21,6 +21,8 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Linq;
+using EventFlow.Core;
 using EventFlow.Snapshots;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Extensions;
@@ -44,6 +46,7 @@ namespace EventFlow.Tests.UnitTests.Snapshots
                     aggregate_sequence_number = "42",
                     snapshot_name = "thingy",
                     snapshot_version = "84",
+                    previous_source_ids = "cool,magic,"
                 }.ToJson();
 
             // Act
@@ -55,6 +58,7 @@ namespace EventFlow.Tests.UnitTests.Snapshots
             snapshotMetadata.AggregateSequenceNumber.Should().Be(42);
             snapshotMetadata.SnapshotName.Should().Be("thingy");
             snapshotMetadata.SnapshotVersion.Should().Be(84);
+            snapshotMetadata.PreviousSourceIds.Select(s => s.Value).Should().BeEquivalentTo("cool", "magic");
         }
 
         [Test]
@@ -68,6 +72,11 @@ namespace EventFlow.Tests.UnitTests.Snapshots
                     AggregateSequenceNumber = 42,
                     SnapshotName = "thingy",
                     SnapshotVersion = 84,
+                    PreviousSourceIds = new []
+                        {
+                            new SourceId("cool"),
+                            new SourceId("magic")
+                        }
                 };
 
             // Act
@@ -80,6 +89,7 @@ namespace EventFlow.Tests.UnitTests.Snapshots
             deserializedSnapshotMetadata.AggregateSequenceNumber.Should().Be(42);
             deserializedSnapshotMetadata.SnapshotName.Should().Be("thingy");
             deserializedSnapshotMetadata.SnapshotVersion.Should().Be(84);
+            deserializedSnapshotMetadata.PreviousSourceIds.Select(s => s.Value).Should().BeEquivalentTo("cool", "magic");
         }
 
         [Test]

--- a/Source/EventFlow/Snapshots/SnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadata.cs
@@ -56,36 +56,36 @@ namespace EventFlow.Snapshots
         [JsonIgnore]
         public string AggregateId
         {
-            get { return GetMetadataValue(SnapshotMetadataKeys.AggregateId); }
-            set { Add(SnapshotMetadataKeys.AggregateId, value); }
+            get => GetMetadataValue(SnapshotMetadataKeys.AggregateId);
+            set => Add(SnapshotMetadataKeys.AggregateId, value);
         }
 
         [JsonIgnore]
         public string AggregateName
         {
-            get { return GetMetadataValue(SnapshotMetadataKeys.AggregateName); }
-            set { Add(SnapshotMetadataKeys.AggregateName, value); }
+            get => GetMetadataValue(SnapshotMetadataKeys.AggregateName);
+            set => Add(SnapshotMetadataKeys.AggregateName, value);
         }
 
         [JsonIgnore]
         public int AggregateSequenceNumber
         {
-            get { return GetMetadataValue(SnapshotMetadataKeys.AggregateSequenceNumber, int.Parse); }
-            set { Add(SnapshotMetadataKeys.AggregateSequenceNumber, value.ToString(CultureInfo.InvariantCulture)); }
+            get => GetMetadataValue(SnapshotMetadataKeys.AggregateSequenceNumber, int.Parse);
+            set => Add(SnapshotMetadataKeys.AggregateSequenceNumber, value.ToString(CultureInfo.InvariantCulture));
         }
 
         [JsonIgnore]
         public string SnapshotName
         {
-            get { return GetMetadataValue(SnapshotMetadataKeys.SnapshotName); }
-            set { Add(SnapshotMetadataKeys.SnapshotName, value); }
+            get => GetMetadataValue(SnapshotMetadataKeys.SnapshotName);
+            set => Add(SnapshotMetadataKeys.SnapshotName, value);
         }
 
         [JsonIgnore]
         public int SnapshotVersion
         {
-            get { return GetMetadataValue(SnapshotMetadataKeys.SnapshotVersion, int.Parse); }
-            set { Add(SnapshotMetadataKeys.SnapshotVersion, value.ToString(CultureInfo.InvariantCulture)); }
+            get => GetMetadataValue(SnapshotMetadataKeys.SnapshotVersion, int.Parse);
+            set => Add(SnapshotMetadataKeys.SnapshotVersion, value.ToString(CultureInfo.InvariantCulture));
         }
 
         [JsonIgnore]
@@ -93,18 +93,18 @@ namespace EventFlow.Snapshots
         {
             get
             {
-                return GetMetadataValue(SnapshotMetadataKeys.PreviousSourceIds, (json) =>
-                    string.IsNullOrWhiteSpace(json) ? 
-                        Empty : 
-                        json
-                            .Split(SourceIdSeparators, StringSplitOptions.RemoveEmptyEntries)
-                            .Select(sourceId => new SourceId(sourceId))
-                            .ToList().AsReadOnly());
+                if (!TryGetValue(SnapshotMetadataKeys.PreviousSourceIds, out var ids) ||
+                    string.IsNullOrEmpty(ids))
+                {
+                    return Empty;
+                }
+
+                return ids
+                    .Split(SourceIdSeparators, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(sourceId => new SourceId(sourceId))
+                    .ToArray();
             }
-            set { Add(SnapshotMetadataKeys.PreviousSourceIds, string.Join(",", value.Select(x => x.Value)));}
+            set => Add(SnapshotMetadataKeys.PreviousSourceIds, string.Join(",", value.Select(x => x.Value)));
         }
-
-
-
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,9 +30,9 @@ services:
   - mssql2017
   - postgresql101
 
-on_success:
-- choco install codecov
-- codecov -f "Build\\Reports\\opencover-results.xml"
+#on_success:
+#- choco install codecov
+#- codecov -f "Build\\Reports\\opencover-results.xml"
 
 nuget:
   account_feed: false


### PR DESCRIPTION
Do not throw `MetadataKeyNotFoundException` if there is no meta data on `previous_source_ids` in snapshots.

Fixes #889