### PR TITLE
Corrects the spelling of ISnapshotSerilizer and SnapshotSerilizer

### DIFF
--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerializerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerializerTests.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -22,14 +22,14 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using EventFlow.Configuration;
-using NUnit.Framework;
 using EventFlow.Snapshots;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates.Snapshots;
+using NUnit.Framework;
 
 namespace EventFlow.Tests.UnitTests.EventStores.Snapshots
 {
-    public class SnapshotSerilizerTests : TestsFor<SnapshotSerilizer>
+    public class SnapshotSerializerTests : TestsFor<SnapshotSerializer>
     {
         [SetUp]
         public void SetUp()

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerializerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerializerTests.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -38,7 +38,7 @@ using NUnit.Framework;
 namespace EventFlow.Tests.UnitTests.Snapshots
 {
     [Category(Categories.Unit)]
-    public class SnapshotSerilizerTests : TestsFor<SnapshotSerilizer>
+    public class SnapshotSerializerTests : TestsFor<SnapshotSerializer>
     {
         private Mock<ISnapshotUpgradeService> _snapshotUpgradeServiceMock;
         private Mock<ISnapshotDefinitionService> _snapshotDefinitionService;

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -21,9 +21,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using EventFlow.Aggregates;
 using EventFlow.Commands;
 using EventFlow.Configuration;
@@ -47,21 +44,26 @@ using EventFlow.Subscribers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace EventFlow
 {
     public class EventFlowOptions : IEventFlowOptions
     {
         private readonly List<Type> _aggregateEventTypes = new List<Type>();
-        private readonly List<Type> _sagaTypes = new List<Type>(); 
+        private readonly List<Type> _sagaTypes = new List<Type>();
         private readonly List<Type> _commandTypes = new List<Type>();
         private readonly EventFlowConfiguration _eventFlowConfiguration = new EventFlowConfiguration();
+
         private readonly List<Type> _jobTypes = new List<Type>
             {
                 typeof(PublishCommandJob),
                 typeof(DispatchToAsynchronousEventSubscribersJob)
             };
-        private readonly List<Type> _snapshotTypes = new List<Type>(); 
+
+        private readonly List<Type> _snapshotTypes = new List<Type>();
 
         public IServiceCollection ServiceCollection { get; }
 
@@ -74,6 +76,7 @@ namespace EventFlow
 
         public static IEventFlowOptions New() => new EventFlowOptions(new ServiceCollection()
             .AddLogging(b => b.AddConsole()));
+
         public static IEventFlowOptions New(IServiceCollection serviceCollection) => new EventFlowOptions(serviceCollection);
 
         public IEventFlowOptions ConfigureOptimisticConcurrencyRetry(int retries, TimeSpan delayBeforeRetry)
@@ -164,6 +167,8 @@ namespace EventFlow
         {
             serviceCollection.AddMemoryCache();
 
+            RegisterObsoleteDefaults(serviceCollection);
+
             // Default no-op resilience strategies
             serviceCollection.TryAddTransient<IAggregateStoreResilienceStrategy, NoAggregateStoreResilienceStrategy>();
             serviceCollection.TryAddTransient<IDispatchToReadStoresResilienceStrategy, NoDispatchToReadStoresResilienceStrategy>();
@@ -176,7 +181,7 @@ namespace EventFlow
             serviceCollection.TryAddTransient<ICommandBus, CommandBus>();
             serviceCollection.TryAddTransient<IAggregateStore, AggregateStore>();
             serviceCollection.TryAddTransient<ISnapshotStore, SnapshotStore>();
-            serviceCollection.TryAddTransient<ISnapshotSerilizer, SnapshotSerilizer>();
+            serviceCollection.TryAddTransient<ISnapshotSerializer, SnapshotSerializer>();
             serviceCollection.TryAddTransient<ISnapshotPersistence, NullSnapshotPersistence>();
             serviceCollection.TryAddTransient<ISnapshotUpgradeService, SnapshotUpgradeService>();
             serviceCollection.TryAddTransient<IReadModelPopulator, ReadModelPopulator>();
@@ -216,6 +221,13 @@ namespace EventFlow
                 _aggregateEventTypes,
                 _sagaTypes,
                 _snapshotTypes));
+        }
+
+        private void RegisterObsoleteDefaults(IServiceCollection serviceCollection)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            serviceCollection.TryAddTransient<ISnapshotSerilizer, SnapshotSerilizer>();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -21,13 +21,14 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Core;
 
 namespace EventFlow.Snapshots
 {
-    public interface ISnapshotSerilizer
+    public interface ISnapshotSerializer
     {
         Task<SerializedSnapshot> SerializeAsync<TAggregate, TIdentity, TSnapshot>(
             SnapshotContainer snapshotContainer,
@@ -42,5 +43,11 @@ namespace EventFlow.Snapshots
             where TAggregate : ISnapshotAggregateRoot<TIdentity, TSnapshot>
             where TIdentity : IIdentity
             where TSnapshot : ISnapshot;
+    }
+
+    [Obsolete("Use 'ISnapshotSerializer' instead")]
+    public interface ISnapshotSerilizer : ISnapshotSerializer
+    {
+        // EMPTY
     }
 }

--- a/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -32,15 +32,15 @@ using Microsoft.Extensions.Logging;
 
 namespace EventFlow.Snapshots
 {
-    public class SnapshotSerilizer : ISnapshotSerilizer
+    public class SnapshotSerializer : ISnapshotSerializer
     {
-        private readonly ILogger<SnapshotSerilizer> _logger;
+        private readonly ILogger<SnapshotSerializer> _logger;
         private readonly IJsonSerializer _jsonSerializer;
         private readonly ISnapshotUpgradeService _snapshotUpgradeService;
         private readonly ISnapshotDefinitionService _snapshotDefinitionService;
 
-        public SnapshotSerilizer(
-            ILogger<SnapshotSerilizer> logger,
+        public SnapshotSerializer(
+            ILogger<SnapshotSerializer> logger,
             IJsonSerializer jsonSerializer,
             ISnapshotUpgradeService snapshotUpgradeService,
             ISnapshotDefinitionService snapshotDefinitionService)
@@ -104,6 +104,20 @@ namespace EventFlow.Snapshots
             var upgradedSnapshot = await _snapshotUpgradeService.UpgradeAsync(snapshot, cancellationToken).ConfigureAwait(false);
 
             return new SnapshotContainer(upgradedSnapshot, metadata);
+        }
+    }
+
+    [Obsolete("Use 'SnapshotSerializer' instead")]
+    public class SnapshotSerilizer : SnapshotSerializer, ISnapshotSerilizer
+    {
+        public SnapshotSerilizer(
+            ILogger<SnapshotSerializer> logger,
+            IJsonSerializer jsonSerializer,
+            ISnapshotUpgradeService snapshotUpgradeService,
+            ISnapshotDefinitionService snapshotDefinitionService)
+            : base(logger, jsonSerializer, snapshotUpgradeService, snapshotDefinitionService)
+        {
+            // EMPTY
         }
     }
 }

--- a/Source/EventFlow/Snapshots/SnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/SnapshotStore.cs
@@ -1,19 +1,19 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2015-2020 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -33,16 +33,16 @@ namespace EventFlow.Snapshots
     public class SnapshotStore : ISnapshotStore
     {
         private readonly ILogger<SnapshotStore> _logger;
-        private readonly ISnapshotSerilizer _snapshotSerilizer;
+        private readonly ISnapshotSerializer _snapshotSerializer;
         private readonly ISnapshotPersistence _snapshotPersistence;
 
         public SnapshotStore(
             ILogger<SnapshotStore> logger,
-            ISnapshotSerilizer snapshotSerilizer,
+            ISnapshotSerializer snapshotSerializer,
             ISnapshotPersistence snapshotPersistence)
         {
             _logger = logger;
-            _snapshotSerilizer = snapshotSerilizer;
+            _snapshotSerializer = snapshotSerializer;
             _snapshotPersistence = snapshotPersistence;
         }
 
@@ -71,7 +71,7 @@ namespace EventFlow.Snapshots
                 return null;
             }
 
-            var snapshotContainer = await _snapshotSerilizer.DeserializeAsync<TAggregate, TIdentity, TSnapshot>(
+            var snapshotContainer = await _snapshotSerializer.DeserializeAsync<TAggregate, TIdentity, TSnapshot>(
                 committedSnapshot,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -87,7 +87,7 @@ namespace EventFlow.Snapshots
             where TIdentity : IIdentity
             where TSnapshot : ISnapshot
         {
-            var serializedSnapshot = await _snapshotSerilizer.SerializeAsync<TAggregate, TIdentity, TSnapshot>(
+            var serializedSnapshot = await _snapshotSerializer.SerializeAsync<TAggregate, TIdentity, TSnapshot>(
                 snapshotContainer,
                 cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
This PR corrects the spelling of ISnapshotSerilizer and SnapshotSerilizer as reported by #922.