### PR TITLE
Use Expression to create instance for better performance

### DIFF
--- a/Source/EventFlow/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/AggregateFactory.cs
@@ -29,6 +29,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using EventFlow.Core;
 using EventFlow.Extensions;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EventFlow.Aggregates
@@ -36,12 +37,18 @@ namespace EventFlow.Aggregates
     public class AggregateFactory : IAggregateFactory
     {
         private readonly IServiceProvider _serviceProvider;
-        private static readonly ConcurrentDictionary<Type, AggregateConstruction> AggregateConstructions = new ConcurrentDictionary<Type, AggregateConstruction>();
+
+        private static readonly ConcurrentDictionary<Type, AggregateConstruction> AggregateConstructions =
+            new ConcurrentDictionary<Type, AggregateConstruction>();
+
+        private readonly IMemoryCache _memoryCache;
 
         public AggregateFactory(
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IMemoryCache memoryCache)
         {
             _serviceProvider = serviceProvider;
+            _memoryCache = memoryCache;
         }
 
         public Task<TAggregate> CreateNewAggregateAsync<TAggregate, TIdentity>(TIdentity id)
@@ -52,9 +59,8 @@ namespace EventFlow.Aggregates
                 typeof(TAggregate),
                 _ => CreateAggregateConstruction<TAggregate, TIdentity>());
 
-            var aggregate = aggregateConstruction.CreateInstance(id, _serviceProvider);
-
-            return Task.FromResult((TAggregate)aggregate);
+            return Task.FromResult(
+                aggregateConstruction.CreateInstance<TAggregate, TIdentity>(id, _memoryCache, _serviceProvider));
         }
 
         private static AggregateConstruction CreateAggregateConstruction<TAggregate, TIdentity>()
@@ -66,7 +72,8 @@ namespace EventFlow.Aggregates
 
             if (constructorInfos.Count != 1)
             {
-                throw new ArgumentException($"Aggregate type '{typeof(TAggregate).PrettyPrint()}' doesn't have just one constructor");
+                throw new ArgumentException(
+                    $"Aggregate type '{typeof(TAggregate).PrettyPrint()}' doesn't have just one constructor");
             }
 
             var constructorInfo = constructorInfos.Single();
@@ -96,7 +103,84 @@ namespace EventFlow.Aggregates
                 _identityType = identityType;
             }
 
-            public object CreateInstance(IIdentity identity, IServiceProvider resolver)
+            public TAggregate CreateInstance<TAggregate, TIdentity>(TIdentity identity,
+                IMemoryCache memoryCache,
+                IServiceProvider serviceProvider) where TIdentity : IIdentity
+            {
+                var typeOfTAggregate = typeof(TAggregate);
+                switch (_parameterInfos.Count)
+                {
+                    case 1: // the TAggregate's constructor looks like `public TAggregate(TIdentity id)...`
+                    {
+                        var arg1Type = _parameterInfos.ElementAt(0).ParameterType;
+                        var arg1 = arg1Type == _identityType ? identity : serviceProvider.GetRequiredService(arg1Type);
+                        if (arg1Type == _identityType)
+                        {
+                            var createAggregateFunc = memoryCache.GetOrCreate(typeOfTAggregate,
+                                _ => ReflectionHelper.CompileConstructor<TIdentity, TAggregate>());
+                            return createAggregateFunc(identity);
+                        }
+                        else
+                        {
+                            var createAggregateFunc = memoryCache.GetOrCreate(typeOfTAggregate,
+                                _ => ReflectionHelper.CompileConstructor<TAggregate>(typeOfTAggregate, arg1Type));
+                            return createAggregateFunc(arg1);
+                        }
+                    }
+                    case 2: // the TAggregate's constructor looks like `public TAggregate(T1 t1,T2 t2)...`
+                    {
+                        var arg1Type = _parameterInfos.ElementAt(0).ParameterType;
+                        var arg2Type = _parameterInfos.ElementAt(1).ParameterType;
+                        var arg1 = arg1Type == _identityType ? identity : serviceProvider.GetRequiredService(arg1Type);
+                        var arg2 = arg2Type == _identityType ? identity : serviceProvider.GetRequiredService(arg2Type);
+
+                        var createAggregateFunc = memoryCache.GetOrCreate(typeOfTAggregate,
+                            _ => ReflectionHelper.CompileConstructor<TAggregate>(typeOfTAggregate, arg1Type, arg2Type));
+                        return createAggregateFunc(arg1, arg2);
+                    }
+                    case 3: // the TAggregate's constructor looks like `public TAggregate(T1 t1,T2 t2,T3 t3)...`
+                    {
+                        var arg1Type = _parameterInfos.ElementAt(0).ParameterType;
+                        var arg2Type = _parameterInfos.ElementAt(1).ParameterType;
+                        var arg3Type = _parameterInfos.ElementAt(2).ParameterType;
+                        var arg1 = arg1Type == _identityType ? identity : serviceProvider.GetRequiredService(arg1Type);
+                        var arg2 = arg2Type == _identityType ? identity : serviceProvider.GetRequiredService(arg2Type);
+                        var arg3 = arg3Type == _identityType ? identity : serviceProvider.GetRequiredService(arg3Type);
+
+                        var createAggregateFunc = memoryCache.GetOrCreate(typeOfTAggregate,
+                            _ => ReflectionHelper.CompileConstructor<TAggregate>(typeOfTAggregate,
+                                arg1Type,
+                                arg2Type,
+                                arg3Type));
+                        return createAggregateFunc(arg1, arg2, arg3);
+                    }
+                    case 4: // public TAggregate(T1 t1,T2 t2,T3 t3)
+                    {
+                        var arg1Type = _parameterInfos.ElementAt(0).ParameterType;
+                        var arg2Type = _parameterInfos.ElementAt(1).ParameterType;
+                        var arg3Type = _parameterInfos.ElementAt(2).ParameterType;
+                        var arg4Type = _parameterInfos.ElementAt(3).ParameterType;
+                        var arg1 = arg1Type == _identityType ? identity : serviceProvider.GetRequiredService(arg1Type);
+                        var arg2 = arg2Type == _identityType ? identity : serviceProvider.GetRequiredService(arg2Type);
+                        var arg3 = arg3Type == _identityType ? identity : serviceProvider.GetRequiredService(arg3Type);
+                        var arg4 = arg4Type == _identityType ? identity : serviceProvider.GetRequiredService(arg4Type);
+
+                        var createAggregateFunc = memoryCache.GetOrCreate(typeOfTAggregate,
+                            _ => ReflectionHelper.CompileConstructor<TAggregate>(typeOfTAggregate,
+                                arg1Type,
+                                arg2Type,
+                                arg3Type,
+                                arg4Type));
+                        return createAggregateFunc(arg1, arg2, arg3, arg4);
+                    }
+                    // Constructor's argument count>4 use reflection to create instance
+                    default:
+                        return (TAggregate)CreateInstance(identity, serviceProvider);
+                }
+            }
+
+            private object CreateInstance(IIdentity identity,
+                IServiceProvider resolver)
             {
                 var parameters = new object[_parameterInfos.Count];
                 foreach (var parameterInfo in _parameterInfos)

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using EventFlow.Extensions;
 using EventFlow.ValueObjects;
@@ -38,6 +37,7 @@ namespace EventFlow.Core
         private static readonly string Prefix;
         private static readonly Regex ValueValidation;
         // ReSharper enable StaticMemberInGenericType
+        private static Func<string, T> _createIdentityFunc;
 
         static Identity()
         {
@@ -81,18 +81,9 @@ namespace EventFlow.Core
 
         public static T With(string value)
         {
-            try
-            {
-                return (T)Activator.CreateInstance(typeof(T), value);
-            }
-            catch (TargetInvocationException e)
-            {
-                if (e.InnerException != null)
-                {
-                    throw e.InnerException;
-                }
-                throw;
-            }
+            _createIdentityFunc ??= ReflectionHelper.CompileConstructor<string, T>();
+
+            return _createIdentityFunc(value);
         }
 
         public static T With(Guid guid)

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using EventFlow.Extensions;
+using JetBrains.Annotations;
 
 namespace EventFlow.Core
 {
@@ -39,6 +40,191 @@ namespace EventFlow.Core
                 assembly.Location :
                 Path.GetDirectoryName(assembly.Location);
             return codeBase;
+        }
+
+        public static Func<T> CompileConstructor<T>()
+        {
+            var expr = Expression.New(typeof(T));
+            return Expression.Lambda<Func<T>>(expr).Compile();
+        }
+
+        public static Func<TInterfaceParameter, TResult> CompileConstructor<TInterfaceParameter, TResult>(Type typeOfTInterfaceParameterImpl, Type typeOfTResult)
+        {
+            var constructor = typeOfTResult.GetConstructor(new[] { typeOfTInterfaceParameterImpl });
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfTInterfaceParameterImpl.Name} typeOfTInterfaceParameterImpl)");
+            }
+            var parameter = Expression.Parameter(typeof(TInterfaceParameter));
+
+            var body = Expression.New(constructor, Expression.Convert(parameter, typeOfTInterfaceParameterImpl));
+            var lambda = Expression.Lambda<Func<TInterfaceParameter, TResult>>(body, parameter);
+            return lambda.Compile();
+        }
+
+
+        public static Func<T1, TResult> CompileConstructor<T1, TResult>()
+        {
+            var typeOfT1 = typeof(T1);
+            var typeOfTResult = typeof(TResult);
+            var parameter1 = Expression.Parameter(typeOfT1);
+            var constructor = typeof(TResult).GetConstructor(new[] { typeOfT1 });
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1)");
+            }
+
+            var body = Expression.New(constructor, parameter1);
+            var lambda = Expression.Lambda<Func<T1, TResult>>(body, parameter1);
+            var method = lambda.Compile();
+            return method;
+        }
+
+        public static Func<T1, TResult> CompileConstructor<T1, TResult>(Type typeOfTResult)
+        {
+            var typeOfT1 = typeof(T1);
+            var parameter1 = Expression.Parameter(typeOfT1);
+            var constructor = typeOfTResult.GetConstructor(new[] { typeOfT1 });
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1)");
+            }
+
+            var body = Expression.New(constructor, parameter1);
+            var lambda = Expression.Lambda<Func<T1, TResult>>(body, parameter1);
+            var method = lambda.Compile();
+            return method;
+        }
+
+        public static Func<object, TResult> CompileConstructor<TResult>(Type typeOfTResult, Type typeOfT1)
+        {
+            var constructorArgumentTypes = new[] { typeOfT1 };
+            var parameters = constructorArgumentTypes.Select(_ => Expression.Parameter(typeof(object))).ToArray();
+            var constructor = typeOfTResult.GetConstructor(constructorArgumentTypes);
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1)");
+            }
+
+            var constructorArguments = new Expression[] { Expression.Convert(parameters[0], typeOfT1) };
+
+            var body = Expression.New(constructor, constructorArguments);
+            var lambda = Expression.Lambda<Func<object, TResult>>(body, parameters);
+            var method = lambda.Compile();
+
+            return method;
+        }
+
+        public static Func<object, object, TResult> CompileConstructor<TResult>(Type typeOfTResult, Type typeOfT1, Type typeOfT2)
+        {
+            var constructorArgumentTypes = new[] { typeOfT1, typeOfT2 };
+            var parameters = constructorArgumentTypes.Select(_ => Expression.Parameter(typeof(object))).ToArray();
+            var constructor = typeOfTResult.GetConstructor(constructorArgumentTypes);
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1,{typeOfT2.Name} arg2)");
+            }
+
+            var constructorArguments = new Expression[] { Expression.Convert(parameters[0], typeOfT1), Expression.Convert(parameters[1], typeOfT2) };
+
+            var body = Expression.New(constructor, constructorArguments);
+            var lambda = Expression.Lambda<Func<object, object, TResult>>(body, parameters);
+            var method = lambda.Compile();
+
+            return method;
+        }
+
+        public static Func<object, object, object, TResult> CompileConstructor<TResult>(Type typeOfTResult, Type typeOfT1, Type typeOfT2, Type typeOfT3)
+        {
+            var constructorArgumentTypes = new[] { typeOfT1, typeOfT2, typeOfT3 };
+            var parameters = constructorArgumentTypes.Select(_ => Expression.Parameter(typeof(object))).ToArray();
+            var constructor = typeOfTResult.GetConstructor(constructorArgumentTypes);
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1,{typeOfT2.Name} arg2,{typeOfT3.Name} arg3)");
+            }
+
+            var constructorArguments = new Expression[] {
+            Expression.Convert(parameters[0], typeOfT1),
+            Expression.Convert(parameters[1], typeOfT2) ,
+            Expression.Convert(parameters[2], typeOfT3)
+        };
+
+            var body = Expression.New(constructor, constructorArguments);
+            var lambda = Expression.Lambda<Func<object, object, object, TResult>>(body, parameters);
+            var method = lambda.Compile();
+
+            return method;
+        }
+
+        public static Func<object, object, object, object, TResult> CompileConstructor<TResult>(Type typeOfTResult, Type typeOfT1, Type typeOfT2, Type typeOfT3, Type typeOfT4)
+        {
+            var constructorArgumentTypes = new[] { typeOfT1, typeOfT2, typeOfT3, typeOfT4 };
+            var parameters = constructorArgumentTypes.Select(_ => Expression.Parameter(typeof(object))).ToArray();
+            var constructor = typeOfTResult.GetConstructor(constructorArgumentTypes);
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Type {typeOfTResult.PrettyPrint()} doesn't have constructor of {typeOfTResult.Name}({typeOfT1.Name} arg1,{typeOfT2.Name} arg2,{typeOfT3.Name} arg3,{typeOfT4.Name} arg4)");
+            }
+
+            var constructorArguments = new Expression[] {
+            Expression.Convert(parameters[0], typeOfT1),
+            Expression.Convert(parameters[1], typeOfT2) ,
+            Expression.Convert(parameters[2], typeOfT3),
+            Expression.Convert(parameters[3], typeOfT4)
+        };
+
+            var body = Expression.New(constructor, constructorArguments);
+            var lambda = Expression.Lambda<Func<object, object, object, object, TResult>>(body, parameters);
+            var method = lambda.Compile();
+
+            return method;
+        }
+
+        public static Func<T1, T2, T3, T4, T5, TResult> CompileConstructor<T1, T2, T3, T4, T5, TResult>(
+            [CanBeNull] Type typeOfT1Impl = null,
+            [CanBeNull] Type typeOfT2Impl = null,
+            [CanBeNull] Type typeOfT3Impl = null,
+            [CanBeNull] Type typeOfT4Impl = null,
+            [CanBeNull] Type typeOfT5Impl = null,
+            [CanBeNull] Type typeOfTResultImpl = null
+        )
+        {
+            var inputTypes = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) };
+            var implTypes = new[] { typeOfT1Impl, typeOfT2Impl, typeOfT3Impl, typeOfT4Impl, typeOfT5Impl };
+            var constructArgumentTypes = new Type[inputTypes.Length];
+            for (var i = 0; i < constructArgumentTypes.Length; i++)
+            {
+                constructArgumentTypes[i] = implTypes[i] ?? inputTypes[i];
+            }
+
+            var typeOfResult = typeOfTResultImpl ?? typeof(TResult);
+
+            var constructor = typeOfResult.GetConstructor(constructArgumentTypes);
+            if (constructor == null)
+            {
+                constructor = typeOfResult.GetConstructors()[0];
+            }
+
+            var parameters = inputTypes.Select(Expression.Parameter).ToArray();
+            var constructorArguments = new Expression[inputTypes.Length];
+            for (var i = 0; i < constructorArguments.Length; i++)
+            {
+                //constructorArguments[i] =
+                //    implTypes[i] == null ? parameters[i] : Expression.Convert(parameters[i], implTypes[i]!);
+                if (implTypes[i] == null)
+                {
+                    constructorArguments[i] = parameters[i];
+                }
+                else
+                {
+                    constructorArguments[i] = Expression.Convert(parameters[i], implTypes[i]);
+                }
+            }
+
+            var body = Expression.New(constructor, constructorArguments);
+            var lambda = Expression.Lambda<Func<T1, T2, T3, T4, T5, TResult>>(body, parameters);
+            return lambda.Compile();
         }
 
         /// <summary>
@@ -80,14 +266,14 @@ namespace EventFlow.Core
                 throw new ArgumentException("Incorrect number of arguments");
             }
 
-            var instanceArgument = Expression.Parameter(genericArguments[0]);;
+            var instanceArgument = Expression.Parameter(genericArguments[0]);
 
-            var argumentPairs = funcArgumentList.Zip(methodArgumentList, (s, d) => new {Source = s, Destination = d}).ToList();
+            var argumentPairs = funcArgumentList.Zip(methodArgumentList, (s, d) => new { Source = s, Destination = d }).ToList();
             if (argumentPairs.All(a => a.Source == a.Destination))
             {
                 // No need to do anything fancy, the types are the same
                 var parameters = funcArgumentList.Select(Expression.Parameter).ToList();
-                return Expression.Lambda<TResult>(Expression.Call(instanceArgument, methodInfo, parameters), new [] { instanceArgument }.Concat(parameters)).Compile();
+                return Expression.Lambda<TResult>(Expression.Call(instanceArgument, methodInfo, parameters), new[] { instanceArgument }.Concat(parameters)).Compile();
             }
 
             var lambdaArgument = new List<ParameterExpression>

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using EventFlow.Core;
 using EventFlow.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -35,6 +36,7 @@ namespace EventFlow.ReadStores
         where TReadModel : IReadModel
     {
         private readonly ILogger<ReadModelFactory<TReadModel>> _logger;
+        private static Func<TReadModel> _createReadModelFunc;
 
         static ReadModelFactory()
         {
@@ -70,9 +72,9 @@ namespace EventFlow.ReadStores
                     id);
             }
 
-            var readModel = (TReadModel) Activator.CreateInstance(typeof(TReadModel));
+            _createReadModelFunc ??= ReflectionHelper.CompileConstructor<TReadModel>();
 
-            return Task.FromResult(readModel);
+            return Task.FromResult(_createReadModelFunc());
         }
     }
 }


### PR DESCRIPTION
Use expression to create instance for better performance

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.17763.2628 (1809/October2018Update/Redstone5)
Intel Xeon Platinum 8260 CPU 2.30GHz, 2 CPU, 96 logical and 48 physical cores
.NET SDK=7.0.100-preview.4.22252.9
  [Host]   : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  .NET 6.0 : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT

Job=.NET 6.0  Runtime=.NET 6.0

|                       Method |     Mean |    Error |   StdDev | Ratio | RatioSD | Rank |  Gen 0 | Allocated |
|----------------------------- |---------:|---------:|---------:|------:|--------:|-----:|-------:|----------:|
|       CreateAggregateWithNew | 233.0 ns |  2.00 ns |  1.87 ns |  1.00 |    0.00 |    1 | 0.0203 |     352 B |
|  CreateAggregateWithNewAsync | 247.2 ns |  3.24 ns |  2.87 ns |  1.06 |    0.02 |    2 | 0.0243 |     424 B |
|      CreateAggregateWithFunc | 454.0 ns |  4.44 ns |  4.15 ns |  1.95 |    0.02 |    3 | 0.0277 |     480 B |
| CreateAggregateWithActivator | 592.4 ns | 10.83 ns | 10.13 ns |  2.54 |    0.05 |    4 | 0.0277 |     488 B |


|                         Method |        Mean |     Error |    StdDev |  Ratio | RatioSD | Rank |  Gen 0 | Allocated |
|------------------------------- |------------:|----------:|----------:|-------:|--------:|-----:|-------:|----------:|
|       CreateDomainEventWithNew |    23.20 ns |  2.573 ns |  7.086 ns |   1.00 |    0.00 |    1 |      - |      64 B |
|    CreateMyDomainEventWithFunc | 1,399.32 ns |  4.494 ns |  3.984 ns |  49.84 |    8.33 |    2 | 0.0200 |     512 B |
| CreateDomainEventWithActivator | 2,893.16 ns | 11.964 ns | 10.606 ns | 103.01 |   17.13 |    3 | 0.0800 |   1,448 B |


|                      Method |       Mean |    Error |   StdDev | Ratio | RatioSD | Rank |  Gen 0 | Allocated |
|---------------------------- |-----------:|---------:|---------:|------:|--------:|-----:|-------:|----------:|
|       CreateIdentityWithNew |   623.6 ns |  0.81 ns |  0.63 ns |  1.00 |    0.00 |    1 | 0.0143 |     256 B |
|      CreateIdentityWithFunc |   659.7 ns | 12.83 ns | 12.00 ns |  1.06 |    0.02 |    2 | 0.0143 |     256 B |
| CreateIdentityWithActivator | 1,143.2 ns | 16.16 ns | 15.11 ns |  1.83 |    0.02 |    3 | 0.0343 |     608 B |

|                       Method |      Mean |     Error |    StdDev | Ratio | RatioSD | Rank |  Gen 0 | Allocated |
|----------------------------- |----------:|----------:|----------:|------:|--------:|-----:|-------:|----------:|
|       CreateReadModelWithNew |  2.854 ns | 0.1133 ns | 0.1004 ns |  1.00 |    0.00 |    1 | 0.0014 |      24 B |
|    CreateMyReadModelWithFunc | 28.943 ns | 0.5359 ns | 0.5013 ns | 10.14 |    0.31 |    2 | 0.0055 |      96 B |
| CreateReadModelWithActivator | 34.042 ns | 0.4156 ns | 0.3887 ns | 11.94 |    0.44 |    3 | 0.0055 |      96 B |

this is the benchmark source code [https://github.com/loyldg/EventFlowCreateInstanceBenchmark](https://github.com/loyldg/EventFlowCreateInstanceBenchmark)