### PR TITLE
Pass full copyrights to author!

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2024 Rasmus Mikkelsen
-Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 Rasmus Mikkelsen
+Copyright (c) 2015-2024 Rasmus Mikkelsen
 Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Rasmus Mikkelsen
+Copyright (c) 2015-2023 Rasmus Mikkelsen
 Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,6 @@ EventFlow was originally developed <u>in my spare time</u> while I worked at bot
 The MIT License (MIT)
 
 Copyright (c) 2015-2024 Rasmus Mikkelsen
-Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ category.
 ```
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Rasmus Mikkelsen
+Copyright (c) 2015-2023 Rasmus Mikkelsen
 Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ category.
 
 ## License
 
+EventFlow was originally developed <u>in my spare time</u> while I worked at both
+<a href="https://www.ebay.com/">eBay (2015 to 2021)</a> and
+<a href="https://schibsted.com/">Schibsted (2021 and onward)</a>.
+
 ```
 The MIT License (MIT)
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ category.
 ```
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 Rasmus Mikkelsen
+Copyright (c) 2015-2024 Rasmus Mikkelsen
 Copyright (c) 2015-2021 eBay Software Foundation
 https://github.com/eventflow/EventFlow
 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/DefaultConfigurationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ModelBindingTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTestsBase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/TestAuthenticationMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowJsonOptionsMvcConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
+++ b/Source/EventFlow.AspNetCore/Configuration/EventFlowModelBindingMvcConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
+++ b/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
+++ b/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
+++ b/Source/EventFlow.AspNetCore/EventFlowAspNetCore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/AspNetCoreEventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.AspNetCore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
+++ b/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
+++ b/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
+++ b/Source/EventFlow.AspNetCore/Logging/AspNetCoreLoggerLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserClaimsMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/DefaultUserClaimsMetadataOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/IUserClaimsMetadataOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
+++ b/Source/EventFlow.AspNetCore/ModelBinding/SingleValueModelBinderProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
+++ b/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
+++ b/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
+++ b/Source/EventFlow.AspNetCore/ServiceProvider/HostedBootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/IntegrationTests/AutofacServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
+++ b/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
+++ b/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
+++ b/Source/EventFlow.Autofac/Extensions/EventFlowOptionsAutofacExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
+++ b/Source/EventFlow.Autofac/Registrations/AutofacServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
+++ b/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
+++ b/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
+++ b/Source/EventFlow.CodeStyle.Tests/EventFlowCodeStyleUnitTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeAnalyzer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
+++ b/Source/EventFlow.CodeStyle/TestCategoryAttributeCodeFixProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/IntegrationTests/ServiceCollectionServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
+++ b/Source/EventFlow.DependencyInjection.Tests/UnitTests/ServiceCollectionServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
+++ b/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
+++ b/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
+++ b/Source/EventFlow.DependencyInjection/Extensions/EventFlowOptionsServiceProviderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceCollectionServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ElasticsearchReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/QueryHandlers/ElasticsearchThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/UnitTests/ReadModelDescriptionProviderTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/IndexName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.Elasticsearch/ValueObjects/ReadModelDescription.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
+++ b/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
+++ b/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
+++ b/Source/EventFlow.EntityFramework.Tests/EntityFrameworkTestExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemoryReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/EfInMemorySnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/InMemoryDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTable.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
+++ b/Source/EventFlow.EntityFramework.Tests/InMemory/Infrastructure/IndexingInMemoryTableFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/EfThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/TestDbContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyMessageReadModelEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/Model/ThingyReadModelEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
@@ -99,7 +99,7 @@ namespace EventFlow.EntityFramework.Tests.MsSql
                     CancellationToken.None)
                 .ConfigureAwait(false);
 
-            var address2 = new Address(AddressId.New, "Musterstraße 42.", "6541", "Berlin", "DE");
+            var address2 = new Address(AddressId.New, "Musterstraï¿½e 42.", "6541", "Berlin", "DE");
             await CommandBus
                 .PublishAsync(new AddAddressCommand(id, 
                         address2), 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreIncludeTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/EfMsSqlSnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Address.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/AddressId.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/AddAddressCommand.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Commands/CreatePersonCommand.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/AddressAddedEvent.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Events/PersonCreatedEvent.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Person.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonAggregate.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/PersonId.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/Queries/PersonGetQuery.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/AddressReadModelEntity.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/IncludeTests/ReadModels/PersonReadModelEntity.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/MsSql/MsSqlDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/EfPostgreSqlSnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/PostgreSql/PostgreSqlDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfInMemorySnapshotTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/EfSqliteReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework.Tests/SQLite/SqliteDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/DefaultBulkOperationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/DefaultUniqueConstraintDetectionStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
+++ b/Source/EventFlow.EntityFramework/EntityFrameworkReadModelConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EventEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/DbContextExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/EventFlowOptionsEntityFrameworkExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ExceptionExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/Source/EventFlow.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IBulkOperationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework/IDbContextProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/IDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework/IDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IDbContextProvider.cs
+++ b/Source/EventFlow.EntityFramework/IDbContextProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/IEntityFrameworkConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
+++ b/Source/EventFlow.EntityFramework/IUniqueConstraintDetectionStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/IApplyQueryableIncludeConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeExpression.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/IncludeString.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeEnumerableExpression.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2020 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/Configuration/Includes/ThenIncludeExpression.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2020 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/EntityFrameworkReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
+++ b/Source/EventFlow.EntityFramework/ReadStores/IEntityFrameworkReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/EntityFrameworkSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
+++ b/Source/EventFlow.EntityFramework/SnapshotStores/SnapshotEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
+++ b/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
+++ b/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
+++ b/Source/EventFlow.EventStores.EventStore.Tests/IntegrationTests/EventStoreEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
+++ b/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
+++ b/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
+++ b/Source/EventFlow.EventStores.EventStore/EventStoreEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/CargoReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosDependentOnVoyageQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Cargos/QueryHandlers/GetCargosQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/EventFlowExamplesShippingQueriesInMemory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetAllVoyagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/QueryHandlers/GetVoyagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
+++ b/Source/EventFlow.Examples.Shipping.Queries.InMemory/Voyage/VoyageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/IntegrationTests/Scenarios.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Locations.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/Domain/Model/CargoModel/Speficications/TransportLegsAreConnectedSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/UnitTests/ExternalServices/Routing/RoutingServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
+++ b/Source/EventFlow.Examples.Shipping.Tests/Voyages.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/BookingApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IBookingApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/IScheduleApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
+++ b/Source/EventFlow.Examples.Shipping/Application/ScheduleApplicationService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Cargo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/CargoState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoBookCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Commands/CargoSetItineraryCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLeg.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Entities/TransportLegId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoBookedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Events/CargoItinerarySetEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargoItineraryJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Jobs/VerifyCargosForVoyageJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargoQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Queries/GetCargosDependentOnVoyageQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/RouteSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Specifications/TransportLegsAreConnectedSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/Subscribers/ScheduleChangedSubscriber.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Itinerary.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/CargoModel/ValueObjects/Route.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Events/LocationCreatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/Location.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/LocationModel/LocationState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageCreateCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Commands/VoyageDelayCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovement.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Entities/CarrierMovementId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageCreatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Events/VoyageScheduleUpdatedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetAllVoyagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Queries/GetVoyagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ScheduleBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/ValueObjects/Schedule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/Voyage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Model/VoyageModel/VoyageState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/IUpdateItineraryService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Services/UpdateItineraryService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
+++ b/Source/EventFlow.Examples.Shipping/Domain/Specs.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
+++ b/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
+++ b/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
+++ b/Source/EventFlow.Examples.Shipping/EventFlowExamplesShipping.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/CarrierMovementExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow.Examples.Shipping/Extensions/DateTimeOffsetExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/IRoutingService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
+++ b/Source/EventFlow.Examples.Shipping/ExternalServices/Routing/RoutingService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
+++ b/Source/EventFlow.Hangfire.Tests/Integration/HangfireJobSchedulerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
+++ b/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
+++ b/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
+++ b/Source/EventFlow.Hangfire/Extensions/EventFlowOptionsHangfireExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowHangfireOptions.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
+++ b/Source/EventFlow.Hangfire/Integration/EventFlowResolverActivator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
+++ b/Source/EventFlow.Hangfire/Integration/HangfireJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
+++ b/Source/EventFlow.Hangfire/Integration/IEventFlowHangfireOptions.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
+++ b/Source/EventFlow.Hangfire/Integration/IHangfireJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/IJobDisplayNameBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/IQueueNameProvider.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
+++ b/Source/EventFlow.Hangfire/Integration/JobDisplayNameBuilder.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
+++ b/Source/EventFlow.Hangfire/Integration/QueueNameProvider.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
+++ b/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
+++ b/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
+++ b/Source/EventFlow.Hangfire/Integration/UseQueueFromParameterAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/MongoDbReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/ReadModels/MongoDbThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
+++ b/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
+++ b/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
+++ b/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
+++ b/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
+++ b/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
+++ b/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresMsSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/EventStores/MsSqlScriptsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/MsSqlReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/QueryHandlers/MsSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresMsSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/SnapshotStores/MsSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/IMsSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/EventStores/EventFlowEventStoresMsSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
+++ b/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
+++ b/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
+++ b/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/IMsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/IMsSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/IMsSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/MsSqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/MsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/MsSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlConfiguration.cs
+++ b/Source/EventFlow.MsSql/MsSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/MsSqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/MsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/MsSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlConnection.cs
+++ b/Source/EventFlow.MsSql/MsSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.MsSql/MsSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.MsSql/ReadStores/Attributes/MsSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/IMsSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/EventFlowSnapshotStoresMsSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/Startup.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/ThingyController.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/RestClient.cs
+++ b/Source/EventFlow.Owin.Tests/RestClient.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin.Tests/RestClient.cs
+++ b/Source/EventFlow.Owin.Tests/RestClient.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin.Tests/RestClient.cs
+++ b/Source/EventFlow.Owin.Tests/RestClient.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/EventFlowOwin.cs
+++ b/Source/EventFlow.Owin/EventFlowOwin.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/EventFlowOwin.cs
+++ b/Source/EventFlow.Owin/EventFlowOwin.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/EventFlowOwin.cs
+++ b/Source/EventFlow.Owin/EventFlowOwin.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Owin/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUriMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.Owin/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
+++ b/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
+++ b/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
+++ b/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/RabbitMqConsumer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Exchange.cs
+++ b/Source/EventFlow.RabbitMQ/Exchange.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Exchange.cs
+++ b/Source/EventFlow.RabbitMQ/Exchange.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Exchange.cs
+++ b/Source/EventFlow.RabbitMQ/Exchange.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.RabbitMQ/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/IRabbitMqConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqMessageFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/MessageId.cs
+++ b/Source/EventFlow.RabbitMQ/MessageId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/MessageId.cs
+++ b/Source/EventFlow.RabbitMQ/MessageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/MessageId.cs
+++ b/Source/EventFlow.RabbitMQ/MessageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/RabbitMqDomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RoutingKey.cs
+++ b/Source/EventFlow.RabbitMQ/RoutingKey.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.RabbitMQ/RoutingKey.cs
+++ b/Source/EventFlow.RabbitMQ/RoutingKey.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.RabbitMQ/RoutingKey.cs
+++ b/Source/EventFlow.RabbitMQ/RoutingKey.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/EventStores/SQLiteEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/QueryHandlers/SQLiteThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQLiteThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/SQLiteReadStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/ISQLiteConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
+++ b/Source/EventFlow.SQLite/Connections/SQLiteConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
+++ b/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
+++ b/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
+++ b/Source/EventFlow.SQLite/EventStores/SQLiteEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/ISQLiteErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
+++ b/Source/EventFlow.SQLite/RetryStrategies/SQLiteErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Connections/ISqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/SqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConnection.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Connections/SqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Connections/SqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConnection.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
+++ b/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
+++ b/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
+++ b/Source/EventFlow.Sql/Exceptions/SqlMigrationException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/AssemblyExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/ISqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/SqlScript.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlScript.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/Migrations/SqlScript.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlScript.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/Migrations/SqlScript.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlScript.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.Sql/ReadModels/Attributes/SqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/IReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageAndPingCommand.cs
@@ -1,7 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDomainErrorAfterFirstCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyImportCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMaybePingCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyMultiplePingsCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyNopCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaCompleteCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyRequestSagaStartCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyThrowExceptionInSagaCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Decorators/SomeCommandHandlerDecorator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDomainErrorAfterFirstEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageAddedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyPingEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaCompleteRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaExceptionRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingySagaStartRequestedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/IScopedContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ScopedContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetMessagesQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/ThingyGetVersionQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaCompletedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaPingReceivedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/Events/ThingySagaStartedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Sagas/ThingySagaLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV1.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotV2.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/ThingySnapshotVersion.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV1ToV2Upgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Snapshots/Upgraders/ThingySnapshotV2ToV3Upgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Thingy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ValueObjects/PingId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Categories.cs
+++ b/Source/EventFlow.TestHelpers/Categories.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Categories.cs
+++ b/Source/EventFlow.TestHelpers/Categories.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Categories.cs
+++ b/Source/EventFlow.TestHelpers/Categories.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
+++ b/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
+++ b/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
+++ b/Source/EventFlow.TestHelpers/EventFlowTestHelpers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/AggregateStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/CommandBusExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/MockLogExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ObjectExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/ProcessExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/QueryProcessorExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/HttpHelper.cs
+++ b/Source/EventFlow.TestHelpers/HttpHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/HttpHelper.cs
+++ b/Source/EventFlow.TestHelpers/HttpHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/HttpHelper.cs
+++ b/Source/EventFlow.TestHelpers/HttpHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/IntegrationTest.cs
+++ b/Source/EventFlow.TestHelpers/IntegrationTest.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/IntegrationTest.cs
+++ b/Source/EventFlow.TestHelpers/IntegrationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/IntegrationTest.cs
+++ b/Source/EventFlow.TestHelpers/IntegrationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/LogHelper.cs
+++ b/Source/EventFlow.TestHelpers/LogHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/LogHelper.cs
+++ b/Source/EventFlow.TestHelpers/LogHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/LogHelper.cs
+++ b/Source/EventFlow.TestHelpers/LogHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/ProcessHelper.cs
+++ b/Source/EventFlow.TestHelpers/ProcessHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/ProcessHelper.cs
+++ b/Source/EventFlow.TestHelpers/ProcessHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/ProcessHelper.cs
+++ b/Source/EventFlow.TestHelpers/ProcessHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/IntegrationTestSuiteForServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForInMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForSnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/TcpHelper.cs
+++ b/Source/EventFlow.TestHelpers/TcpHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/TcpHelper.cs
+++ b/Source/EventFlow.TestHelpers/TcpHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/TcpHelper.cs
+++ b/Source/EventFlow.TestHelpers/TcpHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Test.cs
+++ b/Source/EventFlow.TestHelpers/Test.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/Test.cs
+++ b/Source/EventFlow.TestHelpers/Test.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/Test.cs
+++ b/Source/EventFlow.TestHelpers/Test.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/TestsFor.cs
+++ b/Source/EventFlow.TestHelpers/TestsFor.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/TestsFor.cs
+++ b/Source/EventFlow.TestHelpers/TestsFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/TestsFor.cs
+++ b/Source/EventFlow.TestHelpers/TestsFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/WaitHelper.cs
+++ b/Source/EventFlow.TestHelpers/WaitHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.TestHelpers/WaitHelper.cs
+++ b/Source/EventFlow.TestHelpers/WaitHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.TestHelpers/WaitHelper.cs
+++ b/Source/EventFlow.TestHelpers/WaitHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/EventFlowTests.cs
+++ b/Source/EventFlow.Tests/EventFlowTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/EventFlowTests.cs
+++ b/Source/EventFlow.Tests/EventFlowTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/EventFlowTests.cs
+++ b/Source/EventFlow.Tests/EventFlowTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/CustomAggregateIdExplorationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
+++ b/Source/EventFlow.Tests/Exploration/EventUpgradeExplorationTest.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
+++ b/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
+++ b/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
+++ b/Source/EventFlow.Tests/Exploration/RegisterSubscribersExplorationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Helpers.cs
+++ b/Source/EventFlow.Tests/Helpers.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/Helpers.cs
+++ b/Source/EventFlow.Tests/Helpers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/Helpers.cs
+++ b/Source/EventFlow.Tests/Helpers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Aggregates/AggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BackwardCompatibilityTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/BasicTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Core/IoC/EventFlowServiceRegistrationIntegrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/FilesEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/EventStores/InMemoryEventStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Jobs/InstantJobSchedulerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Logs/LibLogTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/InMemoryReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/QueryHandlers/InMemoryThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AggregateSagaTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/SagaErrorHandlerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SeparationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/SnapshotStores/InMemorySnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/LicenseHeaderTests.cs
+++ b/Source/EventFlow.Tests/LicenseHeaderTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/LicenseHeaderTests.cs
+++ b/Source/EventFlow.Tests/LicenseHeaderTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
@@ -44,14 +44,21 @@ namespace EventFlow.Tests
                 Path.Combine("EventFlow", "Core", "HashHelper.cs"),
                 Path.Combine("EventFlow", "Logs", "Internals", "ImportedLibLog.cs")
             };
-        private static readonly ISet<string> ValidCopyrightNames = new HashSet<string>
+        private static readonly ISet<string> CurrentCopyrightHolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "Rasmus Mikkelsen",
-                "eBay Software Foundation"
+            };
+        private static readonly ISet<string> PastCopyrightHolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "eBay Software Foundation",
+                "Schibsted",
             };
         private static readonly Regex CopyrightLineExtractor = new Regex(
-            @"Copyright \(c\) 20\d{2}\-20\d{2} (?<name>.*)",
+            @"Copyright \(c\) (?<from>20\d{2})\-(?<to>20\d{2}) (?<name>.*)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly int CurrentYear = 2023; // Hardcoded, we don't want test failing every January 1'st
+        private static readonly int EndYearForPastCopyrightHolders = 2022;
 
         [Test]
         public async Task EveryFileHasCorrectLicenseHeader()
@@ -72,16 +79,16 @@ namespace EventFlow.Tests
             missingHeaders.ForEach(Console.WriteLine);
 
             // Missing name in header as defined by the CLA (current license)
-            var missingNameInHeader = sourceFiles
-                .Where(s => !s.Copyright.All(ValidCopyrightNames.Contains))
+            var validationErrors = sourceFiles
+                .Where(s => s.ValidationErrors.Any())
                 .Where(s => !ExternalFiles.Contains(PathRelativeTo(sourceRoot, s.Path)))
                 .ToList();
             Console.WriteLine("File with incorrect name in header according to CLA");
-            missingNameInHeader.ForEach(Console.WriteLine);
+            validationErrors.ForEach(Console.WriteLine);
 
             // Asserts
             missingHeaders.Should().BeEmpty();
-            missingNameInHeader.Should().BeEmpty();
+            validationErrors.Should().BeEmpty();
         }
 
         private static string PathRelativeTo(string root, string fullPath)
@@ -119,7 +126,10 @@ namespace EventFlow.Tests
             var copyright = license
                 .Select(l => CopyrightLineExtractor.Match(l))
                 .Where(m => m.Success)
-                .Select(m => m.Groups["name"].Value)
+                .Select(m => new Copyright(
+                    m.Groups["name"].Value,
+                    (int.Parse(m.Groups["from"].Value), int.Parse(m.Groups["to"].Value)))
+                    )
                 .ToList();
 
             return new SourceFile(
@@ -128,25 +138,71 @@ namespace EventFlow.Tests
                 copyright);
         }
 
+        private class Copyright
+        {
+            public string Name { get; }
+            public (int, int) Year { get; }
+
+            public bool IsCurrent => CurrentCopyrightHolders.Contains(Name);
+
+            public IEnumerable<string> ValidationErrors()
+            {
+                if (IsCurrent)
+                {
+                    if (Year.Item2 != CurrentYear)
+                    {
+                        yield return $"Year for current copyright holder '{Name}' is not correct, should be {CurrentYear}";
+                    }
+
+                    yield break;
+                }
+
+                if (PastCopyrightHolders.Contains(Name))
+                {
+                    if (Year.Item2 > EndYearForPastCopyrightHolders)
+                    {
+                        yield return $"Year for past copyright holder '{Name}' ended {PastCopyrightHolders}, not {Year.Item2}";
+                    }
+                    yield break;
+                }
+
+                yield return $"Unknown copyright holder '{Name}'";
+            }
+
+            public Copyright(
+                string name,
+                (int, int) year)
+            {
+                Name = name;
+                Year = year;
+            }
+        }
+
         private class SourceFile
         {
             public string Path { get; }
             public IReadOnlyCollection<string> License { get; }
-            public IReadOnlyCollection<string> Copyright { get; }
+            public IReadOnlyCollection<Copyright> Copyright { get; }
+            public IReadOnlyCollection<string> ValidationErrors => _validationErrors.Value;
+
+            private readonly Lazy<IReadOnlyCollection<string>> _validationErrors;
 
             public SourceFile(
                 string path,
                 IReadOnlyCollection<string> license,
-                IReadOnlyCollection<string> copyright)
+                IReadOnlyCollection<Copyright> copyright)
             {
                 Path = path;
                 License = license;
                 Copyright = copyright;
+
+                _validationErrors = new Lazy<IReadOnlyCollection<string>>(
+                        () => Copyright.SelectMany(c => c.ValidationErrors()).ToArray());
             }
 
             public override string ToString()
             {
-                return Path;
+                return $"{Path}: {string.Join(", ", ValidationErrors)}";
             }
         }
     }

--- a/Source/EventFlow.Tests/LicenseHeaderTests.cs
+++ b/Source/EventFlow.Tests/LicenseHeaderTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateIdTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootApplyEventTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootNameTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStateTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/MetadataTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/CommandBusTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/CommandTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Commands/DistinctCommandTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Decorators/DecoratorServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/ModuleRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Registrations/FlowIoCServiceRegistrationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/CircularBufferTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/IdentityTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/LabelTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryDelayTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/RetryStrategies/OptimisticConcurrencyRetryStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/TransientFaultHandlerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventUpgradeManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotSerilizerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/TypeExtensionsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Jobs/JobDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Provided/Specifications/AtLeastSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Queries/QueryProcessorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/AsyncReadModelPopulatorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/BaseReadModelTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelPopulatorTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/SingleAggregateReadStoreManagerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestAsyncReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/TestReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/SagaAggregateStoreTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/SagaDefinitionServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotAggregateRootTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotMetadataTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotSerilizerTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/SnapshotUpgradeServiceTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotEveryFewVersionsStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Snapshots/Strategies/SnapshotRandomlyStrategyTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/ExpressionSpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/SpecificationTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecifications.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Specifications/TestSpecificationsTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Subscribers/DispatchToEventSubscribersTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectConverterTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/ValueObjectTests.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/AggregateEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/AggregateEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/AggregateEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/AggregateFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/AggregateFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/AggregateFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateName.cs
+++ b/Source/EventFlow/Aggregates/AggregateName.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateName.cs
+++ b/Source/EventFlow/Aggregates/AggregateName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateName.cs
+++ b/Source/EventFlow/Aggregates/AggregateName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
+++ b/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
+++ b/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
+++ b/Source/EventFlow/Aggregates/AggregateNameAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateState.cs
+++ b/Source/EventFlow/Aggregates/AggregateState.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateState.cs
+++ b/Source/EventFlow/Aggregates/AggregateState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateState.cs
+++ b/Source/EventFlow/Aggregates/AggregateState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
+++ b/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
+++ b/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
+++ b/Source/EventFlow/Aggregates/AggregateUpdateResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/DomainEvent.cs
+++ b/Source/EventFlow/Aggregates/DomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/EventId.cs
+++ b/Source/EventFlow/Aggregates/EventId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/EventId.cs
+++ b/Source/EventFlow/Aggregates/EventId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/EventId.cs
+++ b/Source/EventFlow/Aggregates/EventId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/ExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/FailedExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/IExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
+++ b/Source/EventFlow/Aggregates/ExecutionResults/SuccessExecutionResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/IAggregateEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IAggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/IAggregateEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateEvent.cs
+++ b/Source/EventFlow/Aggregates/IAggregateEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/IAggregateFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IAggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/IAggregateFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateFactory.cs
+++ b/Source/EventFlow/Aggregates/IAggregateFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateName.cs
+++ b/Source/EventFlow/Aggregates/IAggregateName.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IAggregateName.cs
+++ b/Source/EventFlow/Aggregates/IAggregateName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateName.cs
+++ b/Source/EventFlow/Aggregates/IAggregateName.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateStore.cs
+++ b/Source/EventFlow/Aggregates/IAggregateStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IAggregateStore.cs
+++ b/Source/EventFlow/Aggregates/IAggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IAggregateStore.cs
+++ b/Source/EventFlow/Aggregates/IAggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IApply.cs
+++ b/Source/EventFlow/Aggregates/IApply.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IApply.cs
+++ b/Source/EventFlow/Aggregates/IApply.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IApply.cs
+++ b/Source/EventFlow/Aggregates/IApply.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IDomainEvent.cs
+++ b/Source/EventFlow/Aggregates/IDomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEmit.cs
+++ b/Source/EventFlow/Aggregates/IEmit.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IEmit.cs
+++ b/Source/EventFlow/Aggregates/IEmit.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEmit.cs
+++ b/Source/EventFlow/Aggregates/IEmit.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEventApplier.cs
+++ b/Source/EventFlow/Aggregates/IEventApplier.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IEventApplier.cs
+++ b/Source/EventFlow/Aggregates/IEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEventApplier.cs
+++ b/Source/EventFlow/Aggregates/IEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEventId.cs
+++ b/Source/EventFlow/Aggregates/IEventId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IEventId.cs
+++ b/Source/EventFlow/Aggregates/IEventId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IEventId.cs
+++ b/Source/EventFlow/Aggregates/IEventId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IMetadata.cs
+++ b/Source/EventFlow/Aggregates/IMetadata.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/IMetadata.cs
+++ b/Source/EventFlow/Aggregates/IMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/IMetadata.cs
+++ b/Source/EventFlow/Aggregates/IMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/Metadata.cs
+++ b/Source/EventFlow/Aggregates/Metadata.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/Metadata.cs
+++ b/Source/EventFlow/Aggregates/Metadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/Metadata.cs
+++ b/Source/EventFlow/Aggregates/Metadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/MetadataKeys.cs
+++ b/Source/EventFlow/Aggregates/MetadataKeys.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Aggregates/MetadataKeys.cs
+++ b/Source/EventFlow/Aggregates/MetadataKeys.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Aggregates/MetadataKeys.cs
+++ b/Source/EventFlow/Aggregates/MetadataKeys.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/CommandBus.cs
+++ b/Source/EventFlow/CommandBus.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/Command.cs
+++ b/Source/EventFlow/Commands/Command.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/Command.cs
+++ b/Source/EventFlow/Commands/Command.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/Command.cs
+++ b/Source/EventFlow/Commands/Command.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandDefinition.cs
+++ b/Source/EventFlow/Commands/CommandDefinition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandDefinition.cs
+++ b/Source/EventFlow/Commands/CommandDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandDefinition.cs
+++ b/Source/EventFlow/Commands/CommandDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/CommandDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/CommandDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/CommandDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandHandler.cs
+++ b/Source/EventFlow/Commands/CommandHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandHandler.cs
+++ b/Source/EventFlow/Commands/CommandHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandHandler.cs
+++ b/Source/EventFlow/Commands/CommandHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandId.cs
+++ b/Source/EventFlow/Commands/CommandId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandId.cs
+++ b/Source/EventFlow/Commands/CommandId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandId.cs
+++ b/Source/EventFlow/Commands/CommandId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandScheduler.cs
+++ b/Source/EventFlow/Commands/CommandScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandScheduler.cs
+++ b/Source/EventFlow/Commands/CommandScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandScheduler.cs
+++ b/Source/EventFlow/Commands/CommandScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandVersionAttribute.cs
+++ b/Source/EventFlow/Commands/CommandVersionAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/CommandVersionAttribute.cs
+++ b/Source/EventFlow/Commands/CommandVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/CommandVersionAttribute.cs
+++ b/Source/EventFlow/Commands/CommandVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/DistinctCommand.cs
+++ b/Source/EventFlow/Commands/DistinctCommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/DistinctCommand.cs
+++ b/Source/EventFlow/Commands/DistinctCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/DistinctCommand.cs
+++ b/Source/EventFlow/Commands/DistinctCommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommand.cs
+++ b/Source/EventFlow/Commands/ICommand.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ICommand.cs
+++ b/Source/EventFlow/Commands/ICommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommand.cs
+++ b/Source/EventFlow/Commands/ICommand.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/ICommandDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ICommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/ICommandDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandDefinitionService.cs
+++ b/Source/EventFlow/Commands/ICommandDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandHandler.cs
+++ b/Source/EventFlow/Commands/ICommandHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ICommandHandler.cs
+++ b/Source/EventFlow/Commands/ICommandHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandHandler.cs
+++ b/Source/EventFlow/Commands/ICommandHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandId.cs
+++ b/Source/EventFlow/Commands/ICommandId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ICommandId.cs
+++ b/Source/EventFlow/Commands/ICommandId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandId.cs
+++ b/Source/EventFlow/Commands/ICommandId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandScheduler.cs
+++ b/Source/EventFlow/Commands/ICommandScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ICommandScheduler.cs
+++ b/Source/EventFlow/Commands/ICommandScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ICommandScheduler.cs
+++ b/Source/EventFlow/Commands/ICommandScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/ISerializedCommandPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/SerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/SerializedCommandPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Commands/SerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/SerializedCommandPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Commands/SerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/SerializedCommandPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/Bootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/DefinitionServicesInitilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
+++ b/Source/EventFlow/Configuration/Bootstraps/IBootstrapper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
+++ b/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
+++ b/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
+++ b/Source/EventFlow/Configuration/Cancellation/CancellationBoundary.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
+++ b/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
+++ b/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
+++ b/Source/EventFlow/Configuration/Cancellation/ICancellationConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/DecoratorService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
+++ b/Source/EventFlow/Configuration/Decorators/IDecoratorService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/EventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/EventFlowConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/EventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/EventFlowConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/EventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/EventFlowConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IBootstrap.cs
+++ b/Source/EventFlow/Configuration/IBootstrap.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IBootstrap.cs
+++ b/Source/EventFlow/Configuration/IBootstrap.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IBootstrap.cs
+++ b/Source/EventFlow/Configuration/IBootstrap.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
+++ b/Source/EventFlow/Configuration/IEventFlowConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/ILoadedVersionedTypes.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IModule.cs
+++ b/Source/EventFlow/Configuration/IModule.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IModule.cs
+++ b/Source/EventFlow/Configuration/IModule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IModule.cs
+++ b/Source/EventFlow/Configuration/IModule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/IModuleRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/IModuleRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/IModuleRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IResolver.cs
+++ b/Source/EventFlow/Configuration/IResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IResolver.cs
+++ b/Source/EventFlow/Configuration/IResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IResolver.cs
+++ b/Source/EventFlow/Configuration/IResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IResolverContext.cs
+++ b/Source/EventFlow/Configuration/IResolverContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IResolverContext.cs
+++ b/Source/EventFlow/Configuration/IResolverContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IResolverContext.cs
+++ b/Source/EventFlow/Configuration/IResolverContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IRootResolver.cs
+++ b/Source/EventFlow/Configuration/IRootResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IRootResolver.cs
+++ b/Source/EventFlow/Configuration/IRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IRootResolver.cs
+++ b/Source/EventFlow/Configuration/IRootResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IScopeResolver.cs
+++ b/Source/EventFlow/Configuration/IScopeResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IScopeResolver.cs
+++ b/Source/EventFlow/Configuration/IScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IScopeResolver.cs
+++ b/Source/EventFlow/Configuration/IScopeResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IServiceRegistration.cs
+++ b/Source/EventFlow/Configuration/IServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/IServiceRegistration.cs
+++ b/Source/EventFlow/Configuration/IServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/IServiceRegistration.cs
+++ b/Source/EventFlow/Configuration/IServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Lifetime.cs
+++ b/Source/EventFlow/Configuration/Lifetime.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Lifetime.cs
+++ b/Source/EventFlow/Configuration/Lifetime.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Lifetime.cs
+++ b/Source/EventFlow/Configuration/Lifetime.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
+++ b/Source/EventFlow/Configuration/LoadedVersionedTypes.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/ModuleRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/ModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/ModuleRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ModuleRegistration.cs
+++ b/Source/EventFlow/Configuration/ModuleRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ResolverContext.cs
+++ b/Source/EventFlow/Configuration/ResolverContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/ResolverContext.cs
+++ b/Source/EventFlow/Configuration/ResolverContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/ResolverContext.cs
+++ b/Source/EventFlow/Configuration/ResolverContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/ChainedJsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/AsyncHelper.cs
+++ b/Source/EventFlow/Core/AsyncHelper.cs
@@ -1,7 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2013 Tom Jacques (https://github.com/tejacques/AsyncBridge)
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/AsyncHelper.cs
+++ b/Source/EventFlow/Core/AsyncHelper.cs
@@ -2,7 +2,6 @@
 // 
 // Copyright (c) 2013 Tom Jacques (https://github.com/tejacques/AsyncBridge)
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining

--- a/Source/EventFlow/Core/AsyncHelper.cs
+++ b/Source/EventFlow/Core/AsyncHelper.cs
@@ -1,7 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2013 Tom Jacques (https://github.com/tejacques/AsyncBridge)
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/AsyncLock.cs
+++ b/Source/EventFlow/Core/AsyncLock.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/AsyncLock.cs
+++ b/Source/EventFlow/Core/AsyncLock.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/AsyncLock.cs
+++ b/Source/EventFlow/Core/AsyncLock.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/Cache.cs
+++ b/Source/EventFlow/Core/Caching/Cache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/Cache.cs
+++ b/Source/EventFlow/Core/Caching/Cache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/Cache.cs
+++ b/Source/EventFlow/Core/Caching/Cache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/CacheKey.cs
+++ b/Source/EventFlow/Core/Caching/CacheKey.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/CacheKey.cs
+++ b/Source/EventFlow/Core/Caching/CacheKey.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/CacheKey.cs
+++ b/Source/EventFlow/Core/Caching/CacheKey.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/DictionaryMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/IMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/IMemoryCache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/IMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/IMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/IMemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/IMemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/MemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/MemoryCache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/MemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/MemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/MemoryCache.cs
+++ b/Source/EventFlow/Core/Caching/MemoryCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/NullCache.cs
+++ b/Source/EventFlow/Core/Caching/NullCache.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Caching/NullCache.cs
+++ b/Source/EventFlow/Core/Caching/NullCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Caching/NullCache.cs
+++ b/Source/EventFlow/Core/Caching/NullCache.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/CircularBuffer.cs
+++ b/Source/EventFlow/Core/CircularBuffer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/CircularBuffer.cs
+++ b/Source/EventFlow/Core/CircularBuffer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/CircularBuffer.cs
+++ b/Source/EventFlow/Core/CircularBuffer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/DisposableAction.cs
+++ b/Source/EventFlow/Core/DisposableAction.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/DisposableAction.cs
+++ b/Source/EventFlow/Core/DisposableAction.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/DisposableAction.cs
+++ b/Source/EventFlow/Core/DisposableAction.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/GuidFactories.cs
+++ b/Source/EventFlow/Core/GuidFactories.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/GuidFactories.cs
+++ b/Source/EventFlow/Core/GuidFactories.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/GuidFactories.cs
+++ b/Source/EventFlow/Core/GuidFactories.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IIdentity.cs
+++ b/Source/EventFlow/Core/IIdentity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IIdentity.cs
+++ b/Source/EventFlow/Core/IIdentity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IIdentity.cs
+++ b/Source/EventFlow/Core/IIdentity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IJsonSerializer.cs
+++ b/Source/EventFlow/Core/IJsonSerializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IJsonSerializer.cs
+++ b/Source/EventFlow/Core/IJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IJsonSerializer.cs
+++ b/Source/EventFlow/Core/IJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IMetadataContainer.cs
+++ b/Source/EventFlow/Core/IMetadataContainer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IMetadataContainer.cs
+++ b/Source/EventFlow/Core/IMetadataContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IMetadataContainer.cs
+++ b/Source/EventFlow/Core/IMetadataContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IRetryStrategy.cs
+++ b/Source/EventFlow/Core/IRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IRetryStrategy.cs
+++ b/Source/EventFlow/Core/IRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IRetryStrategy.cs
+++ b/Source/EventFlow/Core/IRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ISourceId.cs
+++ b/Source/EventFlow/Core/ISourceId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/ISourceId.cs
+++ b/Source/EventFlow/Core/ISourceId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ISourceId.cs
+++ b/Source/EventFlow/Core/ISourceId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ITransientFaultHandler.cs
+++ b/Source/EventFlow/Core/ITransientFaultHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/ITransientFaultHandler.cs
+++ b/Source/EventFlow/Core/ITransientFaultHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ITransientFaultHandler.cs
+++ b/Source/EventFlow/Core/ITransientFaultHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCResolver.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
+++ b/Source/EventFlow/Core/IoC/EventFlowIoCServiceRegistration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/ConstructorFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/GenericFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
+++ b/Source/EventFlow/Core/IoC/Factories/LambdaFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/IFactory.cs
+++ b/Source/EventFlow/Core/IoC/IFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/IFactory.cs
+++ b/Source/EventFlow/Core/IoC/IFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/IFactory.cs
+++ b/Source/EventFlow/Core/IoC/IFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Registration.cs
+++ b/Source/EventFlow/Core/IoC/Registration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/IoC/Registration.cs
+++ b/Source/EventFlow/Core/IoC/Registration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/IoC/Registration.cs
+++ b/Source/EventFlow/Core/IoC/Registration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/JsonSerializer.cs
+++ b/Source/EventFlow/Core/JsonSerializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/JsonSerializer.cs
+++ b/Source/EventFlow/Core/JsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/JsonSerializer.cs
+++ b/Source/EventFlow/Core/JsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Label.cs
+++ b/Source/EventFlow/Core/Label.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Label.cs
+++ b/Source/EventFlow/Core/Label.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Label.cs
+++ b/Source/EventFlow/Core/Label.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/MetadataContainer.cs
+++ b/Source/EventFlow/Core/MetadataContainer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/MetadataContainer.cs
+++ b/Source/EventFlow/Core/MetadataContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/MetadataContainer.cs
+++ b/Source/EventFlow/Core/MetadataContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Retry.cs
+++ b/Source/EventFlow/Core/Retry.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/Retry.cs
+++ b/Source/EventFlow/Core/Retry.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/Retry.cs
+++ b/Source/EventFlow/Core/Retry.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryDelay.cs
+++ b/Source/EventFlow/Core/RetryDelay.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/RetryDelay.cs
+++ b/Source/EventFlow/Core/RetryDelay.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryDelay.cs
+++ b/Source/EventFlow/Core/RetryDelay.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/IOptimisticConcurrencyRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
+++ b/Source/EventFlow/Core/RetryStrategies/OptimisticConcurrencyRetryStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/SourceId.cs
+++ b/Source/EventFlow/Core/SourceId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/SourceId.cs
+++ b/Source/EventFlow/Core/SourceId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/SourceId.cs
+++ b/Source/EventFlow/Core/SourceId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/TransientFaultHandler.cs
+++ b/Source/EventFlow/Core/TransientFaultHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/TransientFaultHandler.cs
+++ b/Source/EventFlow/Core/TransientFaultHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/TransientFaultHandler.cs
+++ b/Source/EventFlow/Core/TransientFaultHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedType.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Entities/Entity.cs
+++ b/Source/EventFlow/Entities/Entity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Entities/Entity.cs
+++ b/Source/EventFlow/Entities/Entity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Entities/Entity.cs
+++ b/Source/EventFlow/Entities/Entity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Entities/IEntity.cs
+++ b/Source/EventFlow/Entities/IEntity.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Entities/IEntity.cs
+++ b/Source/EventFlow/Entities/IEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Entities/IEntity.cs
+++ b/Source/EventFlow/Entities/IEntity.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllCommittedEventsPage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/AllEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllEventsPage.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/AllEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllEventsPage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/AllEventsPage.cs
+++ b/Source/EventFlow/EventStores/AllEventsPage.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/DomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/DomainEventFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventDefinition.cs
+++ b/Source/EventFlow/EventStores/EventDefinition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventDefinition.cs
+++ b/Source/EventFlow/EventStores/EventDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventDefinition.cs
+++ b/Source/EventFlow/EventStores/EventDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/EventDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/EventDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/EventDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/EventJsonSerializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/EventJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/EventJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventStoreBase.cs
+++ b/Source/EventFlow/EventStores/EventStoreBase.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventStoreBase.cs
+++ b/Source/EventFlow/EventStores/EventStoreBase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventStoreBase.cs
+++ b/Source/EventFlow/EventStores/EventStoreBase.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/EventUpgradeManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventVersionAttribute.cs
+++ b/Source/EventFlow/EventStores/EventVersionAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/EventVersionAttribute.cs
+++ b/Source/EventFlow/EventStores/EventVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/EventVersionAttribute.cs
+++ b/Source/EventFlow/EventStores/EventVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventStoreConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
+++ b/Source/EventFlow/EventStores/Files/IFilesEventStoreConfiguration.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/GlobalPosition.cs
+++ b/Source/EventFlow/EventStores/GlobalPosition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/GlobalPosition.cs
+++ b/Source/EventFlow/EventStores/GlobalPosition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/GlobalPosition.cs
+++ b/Source/EventFlow/EventStores/GlobalPosition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
+++ b/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
+++ b/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
+++ b/Source/EventFlow/EventStores/ICommittedDomainEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IDomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/IDomainEventFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IDomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/IDomainEventFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IDomainEventFactory.cs
+++ b/Source/EventFlow/EventStores/IDomainEventFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/IEventDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/IEventDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventDefinitionService.cs
+++ b/Source/EventFlow/EventStores/IEventDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/IEventJsonSerializer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/IEventJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventJsonSerializer.cs
+++ b/Source/EventFlow/EventStores/IEventJsonSerializer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventPersistence.cs
+++ b/Source/EventFlow/EventStores/IEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventStore.cs
+++ b/Source/EventFlow/EventStores/IEventStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/IEventUpgradeManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/IEventUpgradeManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventUpgradeManager.cs
+++ b/Source/EventFlow/EventStores/IEventUpgradeManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventUpgrader.cs
+++ b/Source/EventFlow/EventStores/IEventUpgrader.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IEventUpgrader.cs
+++ b/Source/EventFlow/EventStores/IEventUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IEventUpgrader.cs
+++ b/Source/EventFlow/EventStores/IEventUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IMetadataProvider.cs
+++ b/Source/EventFlow/EventStores/IMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IMetadataProvider.cs
+++ b/Source/EventFlow/EventStores/IMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IMetadataProvider.cs
+++ b/Source/EventFlow/EventStores/IMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/ISerializedEvent.cs
+++ b/Source/EventFlow/EventStores/ISerializedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/ISerializedEvent.cs
+++ b/Source/EventFlow/EventStores/ISerializedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/ISerializedEvent.cs
+++ b/Source/EventFlow/EventStores/ISerializedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IUncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/IUncommittedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/IUncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/IUncommittedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/IUncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/IUncommittedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
+++ b/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
+++ b/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
+++ b/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/NoAggregateStoreResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/SerializedEvent.cs
+++ b/Source/EventFlow/EventStores/SerializedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/SerializedEvent.cs
+++ b/Source/EventFlow/EventStores/SerializedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/SerializedEvent.cs
+++ b/Source/EventFlow/EventStores/SerializedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/UncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/UncommittedEvent.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/EventStores/UncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/UncommittedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/EventStores/UncommittedEvent.cs
+++ b/Source/EventFlow/EventStores/UncommittedEvent.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/CommandException.cs
+++ b/Source/EventFlow/Exceptions/CommandException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/CommandException.cs
+++ b/Source/EventFlow/Exceptions/CommandException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/CommandException.cs
+++ b/Source/EventFlow/Exceptions/CommandException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/DomainError.cs
+++ b/Source/EventFlow/Exceptions/DomainError.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/DomainError.cs
+++ b/Source/EventFlow/Exceptions/DomainError.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/DomainError.cs
+++ b/Source/EventFlow/Exceptions/DomainError.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/DuplicateOperationException.cs
+++ b/Source/EventFlow/Exceptions/DuplicateOperationException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/DuplicateOperationException.cs
+++ b/Source/EventFlow/Exceptions/DuplicateOperationException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/DuplicateOperationException.cs
+++ b/Source/EventFlow/Exceptions/DuplicateOperationException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
+++ b/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
+++ b/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
+++ b/Source/EventFlow/Exceptions/MetadataKeyNotFoundException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/MetadataParseException.cs
+++ b/Source/EventFlow/Exceptions/MetadataParseException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/MetadataParseException.cs
+++ b/Source/EventFlow/Exceptions/MetadataParseException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/MetadataParseException.cs
+++ b/Source/EventFlow/Exceptions/MetadataParseException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
+++ b/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
+++ b/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
+++ b/Source/EventFlow/Exceptions/NoCommandHandlersException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
+++ b/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
+++ b/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
+++ b/Source/EventFlow/Exceptions/OptimisticConcurrencyException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/SagaPublishException.cs
+++ b/Source/EventFlow/Exceptions/SagaPublishException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/SagaPublishException.cs
+++ b/Source/EventFlow/Exceptions/SagaPublishException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/SagaPublishException.cs
+++ b/Source/EventFlow/Exceptions/SagaPublishException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/UnknownJobException.cs
+++ b/Source/EventFlow/Exceptions/UnknownJobException.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Exceptions/UnknownJobException.cs
+++ b/Source/EventFlow/Exceptions/UnknownJobException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Exceptions/UnknownJobException.cs
+++ b/Source/EventFlow/Exceptions/UnknownJobException.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/AggregateStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/BootstrapperExtensions.cs
+++ b/Source/EventFlow/Extensions/BootstrapperExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/BootstrapperExtensions.cs
+++ b/Source/EventFlow/Extensions/BootstrapperExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/BootstrapperExtensions.cs
+++ b/Source/EventFlow/Extensions/BootstrapperExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow/Extensions/CommandBusExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow/Extensions/CommandBusExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/CommandBusExtensions.cs
+++ b/Source/EventFlow/Extensions/CommandBusExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
+++ b/Source/EventFlow/Extensions/DateTimeOffsetExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DictionaryExtensions.cs
+++ b/Source/EventFlow/Extensions/DictionaryExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/DictionaryExtensions.cs
+++ b/Source/EventFlow/Extensions/DictionaryExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DictionaryExtensions.cs
+++ b/Source/EventFlow/Extensions/DictionaryExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DisposableExtensions.cs
+++ b/Source/EventFlow/Extensions/DisposableExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/DisposableExtensions.cs
+++ b/Source/EventFlow/Extensions/DisposableExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/DisposableExtensions.cs
+++ b/Source/EventFlow/Extensions/DisposableExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsAggregatesExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsBootstrapExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsDefaultExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJobExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsLogExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMemoryCacheExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/EventStoreExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/EventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/EventStoreExtensions.cs
+++ b/Source/EventFlow/Extensions/EventStoreExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/IdentityExtensions.cs
+++ b/Source/EventFlow/Extensions/IdentityExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/IdentityExtensions.cs
+++ b/Source/EventFlow/Extensions/IdentityExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/IdentityExtensions.cs
+++ b/Source/EventFlow/Extensions/IdentityExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
+++ b/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
+++ b/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
+++ b/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelEnvelopeExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ResolverExtensions.cs
+++ b/Source/EventFlow/Extensions/ResolverExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/ResolverExtensions.cs
+++ b/Source/EventFlow/Extensions/ResolverExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/ResolverExtensions.cs
+++ b/Source/EventFlow/Extensions/ResolverExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/SourceIdExtensions.cs
+++ b/Source/EventFlow/Extensions/SourceIdExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/SourceIdExtensions.cs
+++ b/Source/EventFlow/Extensions/SourceIdExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/SourceIdExtensions.cs
+++ b/Source/EventFlow/Extensions/SourceIdExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/SpecificationExtensions.cs
+++ b/Source/EventFlow/Extensions/SpecificationExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/SpecificationExtensions.cs
+++ b/Source/EventFlow/Extensions/SpecificationExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/SpecificationExtensions.cs
+++ b/Source/EventFlow/Extensions/SpecificationExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/StringBuilderExtensions.cs
+++ b/Source/EventFlow/Extensions/StringBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/StringBuilderExtensions.cs
+++ b/Source/EventFlow/Extensions/StringBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/StringBuilderExtensions.cs
+++ b/Source/EventFlow/Extensions/StringBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/StringExtensions.cs
+++ b/Source/EventFlow/Extensions/StringExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/StringExtensions.cs
+++ b/Source/EventFlow/Extensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/StringExtensions.cs
+++ b/Source/EventFlow/Extensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/TypeExtensions.cs
+++ b/Source/EventFlow/Extensions/TypeExtensions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Extensions/TypeExtensions.cs
+++ b/Source/EventFlow/Extensions/TypeExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Extensions/TypeExtensions.cs
+++ b/Source/EventFlow/Extensions/TypeExtensions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ICommandBus.cs
+++ b/Source/EventFlow/ICommandBus.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ICommandBus.cs
+++ b/Source/EventFlow/ICommandBus.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ICommandBus.cs
+++ b/Source/EventFlow/ICommandBus.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/IEventFlowOptions.cs
+++ b/Source/EventFlow/IEventFlowOptions.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/IEventFlowOptions.cs
+++ b/Source/EventFlow/IEventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/IEventFlowOptions.cs
+++ b/Source/EventFlow/IEventFlowOptions.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJob.cs
+++ b/Source/EventFlow/Jobs/IJob.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/IJob.cs
+++ b/Source/EventFlow/Jobs/IJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJob.cs
+++ b/Source/EventFlow/Jobs/IJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/IJobDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/IJobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/IJobDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/IJobDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobId.cs
+++ b/Source/EventFlow/Jobs/IJobId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/IJobId.cs
+++ b/Source/EventFlow/Jobs/IJobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobId.cs
+++ b/Source/EventFlow/Jobs/IJobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobRunner.cs
+++ b/Source/EventFlow/Jobs/IJobRunner.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/IJobRunner.cs
+++ b/Source/EventFlow/Jobs/IJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobRunner.cs
+++ b/Source/EventFlow/Jobs/IJobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobScheduler.cs
+++ b/Source/EventFlow/Jobs/IJobScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/IJobScheduler.cs
+++ b/Source/EventFlow/Jobs/IJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/IJobScheduler.cs
+++ b/Source/EventFlow/Jobs/IJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/InstantJobScheduler.cs
+++ b/Source/EventFlow/Jobs/InstantJobScheduler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/InstantJobScheduler.cs
+++ b/Source/EventFlow/Jobs/InstantJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/InstantJobScheduler.cs
+++ b/Source/EventFlow/Jobs/InstantJobScheduler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobDefinition.cs
+++ b/Source/EventFlow/Jobs/JobDefinition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/JobDefinition.cs
+++ b/Source/EventFlow/Jobs/JobDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobDefinition.cs
+++ b/Source/EventFlow/Jobs/JobDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/JobDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/JobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/JobDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobDefinitionService.cs
+++ b/Source/EventFlow/Jobs/JobDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobId.cs
+++ b/Source/EventFlow/Jobs/JobId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/JobId.cs
+++ b/Source/EventFlow/Jobs/JobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobId.cs
+++ b/Source/EventFlow/Jobs/JobId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobRunner.cs
+++ b/Source/EventFlow/Jobs/JobRunner.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/JobRunner.cs
+++ b/Source/EventFlow/Jobs/JobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobRunner.cs
+++ b/Source/EventFlow/Jobs/JobRunner.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobVersionAttribute.cs
+++ b/Source/EventFlow/Jobs/JobVersionAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Jobs/JobVersionAttribute.cs
+++ b/Source/EventFlow/Jobs/JobVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Jobs/JobVersionAttribute.cs
+++ b/Source/EventFlow/Jobs/JobVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/ConsoleLog.cs
+++ b/Source/EventFlow/Logs/ConsoleLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/ConsoleLog.cs
+++ b/Source/EventFlow/Logs/ConsoleLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/ConsoleLog.cs
+++ b/Source/EventFlow/Logs/ConsoleLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/ILog.cs
+++ b/Source/EventFlow/Logs/ILog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/ILog.cs
+++ b/Source/EventFlow/Logs/ILog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/ILog.cs
+++ b/Source/EventFlow/Logs/ILog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/LibLog.cs
+++ b/Source/EventFlow/Logs/LibLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/LibLog.cs
+++ b/Source/EventFlow/Logs/LibLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/LibLog.cs
+++ b/Source/EventFlow/Logs/LibLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/Log.cs
+++ b/Source/EventFlow/Logs/Log.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/Log.cs
+++ b/Source/EventFlow/Logs/Log.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/Log.cs
+++ b/Source/EventFlow/Logs/Log.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/LogLevel.cs
+++ b/Source/EventFlow/Logs/LogLevel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/LogLevel.cs
+++ b/Source/EventFlow/Logs/LogLevel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/LogLevel.cs
+++ b/Source/EventFlow/Logs/LogLevel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/NullLog.cs
+++ b/Source/EventFlow/Logs/NullLog.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Logs/NullLog.cs
+++ b/Source/EventFlow/Logs/NullLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Logs/NullLog.cs
+++ b/Source/EventFlow/Logs/NullLog.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddEventTypeMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddGuidMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
+++ b/Source/EventFlow/MetadataProviders/AddMachineNameMetadataProvider.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
+++ b/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
+++ b/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
+++ b/Source/EventFlow/Provided/Jobs/DispatchToAsynchronousEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
+++ b/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
+++ b/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
+++ b/Source/EventFlow/Provided/Jobs/PublishCommandJob.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
+++ b/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
+++ b/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
+++ b/Source/EventFlow/Provided/ProvidedJobsConfigurationModule.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AggregateIsNewSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AllSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AllSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/AllSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AllSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AllSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AllSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
+++ b/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
+++ b/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
+++ b/Source/EventFlow/Provided/Specifications/AndSpeficication.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/AtLeastSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/ExpressionSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/NotSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/NotSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/NotSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/NotSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/NotSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/NotSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/OrSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/OrSpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Provided/Specifications/OrSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/OrSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Provided/Specifications/OrSpecification.cs
+++ b/Source/EventFlow/Provided/Specifications/OrSpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQuery.cs
+++ b/Source/EventFlow/Queries/IQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Queries/IQuery.cs
+++ b/Source/EventFlow/Queries/IQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQuery.cs
+++ b/Source/EventFlow/Queries/IQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQueryHandler.cs
+++ b/Source/EventFlow/Queries/IQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Queries/IQueryHandler.cs
+++ b/Source/EventFlow/Queries/IQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQueryHandler.cs
+++ b/Source/EventFlow/Queries/IQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQueryProcessor.cs
+++ b/Source/EventFlow/Queries/IQueryProcessor.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Queries/IQueryProcessor.cs
+++ b/Source/EventFlow/Queries/IQueryProcessor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/IQueryProcessor.cs
+++ b/Source/EventFlow/Queries/IQueryProcessor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/QueryProcessor.cs
+++ b/Source/EventFlow/Queries/QueryProcessor.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Queries/QueryProcessor.cs
+++ b/Source/EventFlow/Queries/QueryProcessor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/QueryProcessor.cs
+++ b/Source/EventFlow/Queries/QueryProcessor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/ReadModelByIdQuery.cs
+++ b/Source/EventFlow/Queries/ReadModelByIdQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Queries/ReadModelByIdQuery.cs
+++ b/Source/EventFlow/Queries/ReadModelByIdQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Queries/ReadModelByIdQuery.cs
+++ b/Source/EventFlow/Queries/ReadModelByIdQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/DispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/DispatchToReadStores.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/DispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/DispatchToReadStores.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/DispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/DispatchToReadStores.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IAmReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmReadModelFor.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStores.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/IDispatchToReadStoresResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModel.cs
+++ b/Source/EventFlow/ReadStores/IReadModel.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModel.cs
+++ b/Source/EventFlow/ReadStores/IReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModel.cs
+++ b/Source/EventFlow/ReadStores/IReadModel.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/IReadModelDomainEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelLocator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelLocator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelLocator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelPopulator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelPopulator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelPopulator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/IReadStoreManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/IReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/IReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/IReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/IReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
+++ b/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
+++ b/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
+++ b/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
+++ b/Source/EventFlow/ReadStores/NoDispatchToReadStoresResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
+++ b/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
+++ b/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
+++ b/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/ReadModelPopulator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/ReadModelPopulator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/ReadModelPopulator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelUpdate.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdate.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelUpdate.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelUpdate.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdate.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
+++ b/Source/EventFlow/ReadStores/ReadModelUpdateResult.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/IAggregateSaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/SagaAggregateStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/IDispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/IDispatchToSagas.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/IDispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/IDispatchToSagas.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/IDispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/IDispatchToSagas.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISaga.cs
+++ b/Source/EventFlow/Sagas/ISaga.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISaga.cs
+++ b/Source/EventFlow/Sagas/ISaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISaga.cs
+++ b/Source/EventFlow/Sagas/ISaga.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaContext.cs
+++ b/Source/EventFlow/Sagas/ISagaContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaContext.cs
+++ b/Source/EventFlow/Sagas/ISagaContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaContext.cs
+++ b/Source/EventFlow/Sagas/ISagaContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/ISagaDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/ISagaDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/ISagaDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/ISagaErrorHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/ISagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/ISagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaHandles.cs
+++ b/Source/EventFlow/Sagas/ISagaHandles.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaHandles.cs
+++ b/Source/EventFlow/Sagas/ISagaHandles.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaHandles.cs
+++ b/Source/EventFlow/Sagas/ISagaHandles.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaId.cs
+++ b/Source/EventFlow/Sagas/ISagaId.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaId.cs
+++ b/Source/EventFlow/Sagas/ISagaId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaId.cs
+++ b/Source/EventFlow/Sagas/ISagaId.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
+++ b/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
+++ b/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
+++ b/Source/EventFlow/Sagas/ISagaIsStartedBy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaLocator.cs
+++ b/Source/EventFlow/Sagas/ISagaLocator.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaLocator.cs
+++ b/Source/EventFlow/Sagas/ISagaLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaLocator.cs
+++ b/Source/EventFlow/Sagas/ISagaLocator.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaStore.cs
+++ b/Source/EventFlow/Sagas/ISagaStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaStore.cs
+++ b/Source/EventFlow/Sagas/ISagaStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaStore.cs
+++ b/Source/EventFlow/Sagas/ISagaStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdateResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaUpdater.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdater.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/ISagaUpdater.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdater.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/ISagaUpdater.cs
+++ b/Source/EventFlow/Sagas/ISagaUpdater.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
+++ b/Source/EventFlow/Sagas/NoSagaUpdateResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaContext.cs
+++ b/Source/EventFlow/Sagas/SagaContext.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaContext.cs
+++ b/Source/EventFlow/Sagas/SagaContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaContext.cs
+++ b/Source/EventFlow/Sagas/SagaContext.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/SagaDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/SagaDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaDefinitionService.cs
+++ b/Source/EventFlow/Sagas/SagaDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaDetails.cs
+++ b/Source/EventFlow/Sagas/SagaDetails.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaDetails.cs
+++ b/Source/EventFlow/Sagas/SagaDetails.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaDetails.cs
+++ b/Source/EventFlow/Sagas/SagaDetails.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/SagaErrorHandler.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/SagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaErrorHandler.cs
+++ b/Source/EventFlow/Sagas/SagaErrorHandler.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaState.cs
+++ b/Source/EventFlow/Sagas/SagaState.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaState.cs
+++ b/Source/EventFlow/Sagas/SagaState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaState.cs
+++ b/Source/EventFlow/Sagas/SagaState.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaStore.cs
+++ b/Source/EventFlow/Sagas/SagaStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaStore.cs
+++ b/Source/EventFlow/Sagas/SagaStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaStore.cs
+++ b/Source/EventFlow/Sagas/SagaStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaUpdater.cs
+++ b/Source/EventFlow/Sagas/SagaUpdater.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Sagas/SagaUpdater.cs
+++ b/Source/EventFlow/Sagas/SagaUpdater.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Sagas/SagaUpdater.cs
+++ b/Source/EventFlow/Sagas/SagaUpdater.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Shims/Tasks.cs
+++ b/Source/EventFlow/Shims/Tasks.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Shims/Tasks.cs
+++ b/Source/EventFlow/Shims/Tasks.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Shims/Tasks.cs
+++ b/Source/EventFlow/Shims/Tasks.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/CommittedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/CommittedSnapshot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/CommittedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/CommittedSnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/CommittedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/CommittedSnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotSerilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
+++ b/Source/EventFlow/Snapshots/ISnapshotUpgrader.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SerializedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/SerializedSnapshot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SerializedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/SerializedSnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SerializedSnapshot.cs
+++ b/Source/EventFlow/Snapshots/SerializedSnapshot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotContainer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotContainer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotContainer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotContainer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotContainer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotDefinition.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinition.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotDefinition.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotDefinition.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinition.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotDefinitionService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadata.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotMetadata.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadata.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
+++ b/Source/EventFlow/Snapshots/SnapshotMetadataKeys.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
+++ b/Source/EventFlow/Snapshots/SnapshotSerilizer.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/SnapshotStore.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/SnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotStore.cs
+++ b/Source/EventFlow/Snapshots/SnapshotStore.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
+++ b/Source/EventFlow/Snapshots/SnapshotUpgradeService.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
+++ b/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
+++ b/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
+++ b/Source/EventFlow/Snapshots/SnapshotVersionAttribute.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/ISnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/InMemory/InMemorySnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
+++ b/Source/EventFlow/Snapshots/Stores/Null/NullSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/ISnapshotStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotEveryFewVersionsStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
+++ b/Source/EventFlow/Snapshots/Strategies/SnapshotRandomlyStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Specifications/ISpecification.cs
+++ b/Source/EventFlow/Specifications/ISpecification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Specifications/ISpecification.cs
+++ b/Source/EventFlow/Specifications/ISpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Specifications/ISpecification.cs
+++ b/Source/EventFlow/Specifications/ISpecification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Specifications/Specification.cs
+++ b/Source/EventFlow/Specifications/Specification.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Specifications/Specification.cs
+++ b/Source/EventFlow/Specifications/Specification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Specifications/Specification.cs
+++ b/Source/EventFlow/Specifications/Specification.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/DomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/DomainEventPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/DomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/DomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/DomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/DomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToEventSubscribers.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/IDispatchToSubscriberResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
+++ b/Source/EventFlow/Subscribers/IDomainEventPublisher.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribe.cs
+++ b/Source/EventFlow/Subscribers/ISubscribe.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/ISubscribe.cs
+++ b/Source/EventFlow/Subscribers/ISubscribe.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribe.cs
+++ b/Source/EventFlow/Subscribers/ISubscribe.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeAsynchronousTo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousTo.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
+++ b/Source/EventFlow/Subscribers/ISubscribeSynchronousToAll.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
+++ b/Source/EventFlow/Subscribers/NoDispatchToSubscriberResilienceStrategy.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/ISingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ISingleValueObject.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ValueObjects/ISingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ISingleValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/ISingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ISingleValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/SingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObject.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ValueObjects/SingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/SingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObjectConverter.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/ValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ValueObject.cs
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow/ValueObjects/ValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/Source/EventFlow/ValueObjects/ValueObject.cs
+++ b/Source/EventFlow/ValueObjects/ValueObject.cs
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,6 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2024 Rasmus Mikkelsen
-// Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2023 Rasmus Mikkelsen
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
 // Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2023 Rasmus Mikkelsen
 // Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 


### PR DESCRIPTION
Copyrights for EventFlow are moving fully to the original author.

EventFlow was originally created in 2015 while I worked at eBay, and while eBay really wants to be part of the open source community, it had some bad experience with e.g. employees leaking company IP. So when I created EventFlow, eBay required me to have partial copyrights to the project. While I certainly did not want this, it did mean that eBay helped me with the initial legal stuff and I could schedule talks with the in-house open-source attorney.

Now fast forward to the year 2021, here Schibsted (authors of e.g. varnish) buys the local brands that I’m part of and thereby the copyrights of EventFlow. Schibsted has an even longer history of ❤️ open-source, which is why today I’m able to announce that Schibsted has given me the full copyrights of EventFlow.

What does this mean for every developer that uses EventFlow? Nothing really, copyrights on MIT licensed open-source projects are AFAIK pretty easy to circumvent for users.

What’s gonna happen with EventFlow? The licence header is being updated, EventFlow will forever stay on the MIT licence and moving the copyrights ensures that I’m able to make that promise.

Disclaimer: I’m no lawyer and don’t have any understanding of the legal parts here. This text is properly gonna get some updates while I get it fully reviewed and approved internally in Schibsted.