### PR TITLE
Add a stale workflow to reduce cognitive load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version:
           3.1.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HELPZ_POSTGRESQL_PASS: Password12!
       EVENTFLOW_MSSQL_SERVER: 127.0.0.1,1433
@@ -68,11 +68,6 @@ jobs:
         dotnet-version:
           3.1.x
           6.0.x
-
-    - name: Fix
-      run: |
-        echo "Trying to fix https://github.com/actions/runner/issues/2364"
-        sudo chown ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Fix
       run: |
         echo "Trying to fix https://github.com/actions/runner/issues/2364"
-        sudo chown ubuntu:ubuntu -R /home/runneradmin
+        sudo chown ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,17 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Setup .NET Core 3.1.x
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: "3.1.x"
-        
-    - name: Setup .NET Core 6.0.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "6.0.x"
+        dotnet-version:
+          3.1.x
+          6.0.x
+
+    - name: Fix
+      run: |
+        echo "Trying to fix https://github.com/actions/runner/issues/2364"
+        sudo chown ubuntu:ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,17 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Setup .NET Core 3.1.x
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: "3.1.x"
-        
-    - name: Setup .NET Core 6.0.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "6.0.x"
+        dotnet-version:
+          3.1.x
+          6.0.x
+
+    - name: Fix
+      run: |
+        echo "Trying to fix https://github.com/actions/runner/issues/2364"
+        sudo chown ubuntu:ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Fix
       run: |
         echo "Trying to fix https://github.com/actions/runner/issues/2364"
-        sudo chown ubuntu:ubuntu -R /home/runneradmin
+        sudo chown ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HELPZ_POSTGRESQL_PASS: Password12!
       EVENTFLOW_MSSQL_SERVER: 127.0.0.1,1433
@@ -68,11 +68,6 @@ jobs:
         dotnet-version:
           3.1.x
           6.0.x
-
-    - name: Fix
-      run: |
-        echo "Trying to fix https://github.com/actions/runner/issues/2364"
-        sudo chown ubuntu -R /home/runneradmin
 
     # Yes, EventFlow has a custom built build tool. If you are reading this
     # you might have a better idea of how to do it alternatively, if so,

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -71,3 +71,7 @@ jobs:
 
           days-before-stale: 90
           days-before-close: 7
+          stale-pr-label: stale
+          stale-issue-label: stale
+          exempt-pr-labels: stale-exempt
+          operations-per-run: 1000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,73 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+            Hello there! 
+
+            We hope you are doing well. We noticed that this issue has not seen any activity in the past 90 days.
+            We consider this issue to be stale and will be closing it within the next seven days. 
+
+            If you still require assistance with this issue, please feel free to reopen it or create a new issue. 
+
+            Thank you for your understanding and cooperation. 
+
+            Best regards, 
+            EventFlow
+
+          close-issue-message: |
+            Hello there! 
+
+            This issue has been closed due to inactivity for seven days. If you believe this issue still
+            needs attention, please feel free to open a new issue or comment on this one to request its
+            reopening. 
+
+            Thank you for your contribution to this repository. 
+
+            Best regards, 
+            EventFlow
+
+          stale-pr-message: |
+            Hello there! 
+
+            We hope this message finds you well. We wanted to let you know that we have noticed that there has been
+            no activity on this pull request for the past 90 days, which makes it a stale pull request. 
+
+            As a result, we will be closing this pull request within the next seven days. If you still
+            think this pull request is necessary or relevant, please feel free to update it or leave a
+            comment within the next seven days. 
+
+            Thank you for your contributions and understanding.
+
+            Best regards,
+            EventFlow
+
+          close-pr-message:
+            Hello there! 
+
+            I'm a bot and I wanted to let you know that your pull request has been closed due to inactivity
+            after being marked as stale for seven days. 
+
+            If you believe this was done in error, or if you still plan to work on this pull request,
+            please don't hesitate to reopen it and let us know. We're always happy to review and
+            merge high-quality contributions. 
+
+            Thank you for your interest in our project!
+
+            Best regards,
+            EventFlow
+
+          days-before-stale: 90
+          days-before-close: 7


### PR DESCRIPTION
Adds a stale workflow to reduce some of the cognitive load in old issues. There are no doubt important information there, but to get the project rebooted and up and running again in an state that is manageable, they will be closed unless someone intervenes.

Thanks for the understanding.

Hope to bring some life back to the v1 development and get it ready.