### PR TITLE
Basic initiated and deletion state validation added as a strategy #992

### DIFF
--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyInitiateCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyInitiateCommand.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,13 +21,38 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using EventFlow.Aggregates;
-using EventFlow.EventStores;
+using EventFlow.Commands;
+using EventFlow.Core;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using System.Threading;
 
-namespace EventFlow.TestHelpers.Aggregates.Events
+namespace EventFlow.TestHelpers.Aggregates.Commands
 {
-    [EventVersion("ThingyDeleted", 1)]
-    public class ThingyDeletedEvent : AggregateEvent<ThingyAggregate, ThingyId>, IDeletedEvent
+    [CommandVersion("ThingyInitiate", 1)]
+    public class ThingyInitiateCommand : Command<ThingyAggregate, ThingyId>, ICommandInitator
     {
+
+        public ThingyInitiateCommand(ThingyId aggregateId)
+            : this(aggregateId, CommandId.New)
+        {   }
+
+        public ThingyInitiateCommand(ThingyId aggregateId, ISourceId sourceId)
+            : base(aggregateId, sourceId)
+        {   }
+
+        [JsonConstructor]
+        public ThingyInitiateCommand(ThingyId aggregateId, SourceId sourceId)
+            : base(aggregateId, sourceId)
+        {   }
+    }
+
+    public class ThingyInitiateCommandHandler : CommandHandler<ThingyAggregate, ThingyId, ThingyInitiateCommand>
+    {
+        public override Task ExecuteAsync(ThingyAggregate aggregate, ThingyInitiateCommand command, CancellationToken cancellationToken)
+        {
+            aggregate.Intiate();
+            return Task.FromResult(0);
+        }
     }
 }

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyPingCommand.cs
@@ -31,7 +31,7 @@ using Newtonsoft.Json;
 namespace EventFlow.TestHelpers.Aggregates.Commands
 {
     [CommandVersion("ThingyPing", 1)]
-    public class ThingyPingCommand : Command<ThingyAggregate, ThingyId>
+    public class ThingyPingCommand : Command<ThingyAggregate, ThingyId>, ICommandInitator
     {
         public PingId PingId { get; }
 

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyInitiatedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyInitiatedEvent.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -26,8 +26,8 @@ using EventFlow.EventStores;
 
 namespace EventFlow.TestHelpers.Aggregates.Events
 {
-    [EventVersion("ThingyDeleted", 1)]
-    public class ThingyDeletedEvent : AggregateEvent<ThingyAggregate, ThingyId>, IDeletedEvent
+    [EventVersion("ThingyInitiatedEvent", 1)]
+    public class ThingyInitiatedEvent : AggregateEvent<ThingyAggregate, ThingyId>
     {
     }
 }

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -40,6 +40,7 @@ namespace EventFlow.TestHelpers.Aggregates
 {
     [AggregateName("Thingy")]
     public class ThingyAggregate : SnapshotAggregateRoot<ThingyAggregate, ThingyId, ThingySnapshot>,
+        IEmit<ThingyInitiatedEvent>,
         IEmit<ThingyDomainErrorAfterFirstEvent>,
         IEmit<ThingyDeletedEvent>,
         IEmit<ThingyUpgradableV1Event>,
@@ -59,7 +60,7 @@ namespace EventFlow.TestHelpers.Aggregates
         public IReadOnlyCollection<PingId> PingsReceived => _pingsReceived;
         public IReadOnlyCollection<ThingyMessage> Messages => _messages;
         public IReadOnlyCollection<ThingySnapshotVersion> SnapshotVersions { get; private set; } = new ThingySnapshotVersion[] {};
-        public bool IsDeleted { get; private set; }
+        public bool IsThingyDeleted { get; private set; }
 
         public int UpgradableEventV1Received { get; private set; }
         public int UpgradableEventV2Received { get; private set; }
@@ -75,6 +76,11 @@ namespace EventFlow.TestHelpers.Aggregates
             Register<ThingySagaStartRequestedEvent>(e => {/* do nothing */});
             Register<ThingySagaCompleteRequestedEvent>(e => {/* do nothing */});
             Register<ThingySagaExceptionRequestedEvent>(e => {/* do nothing */});
+        }
+
+        public void Intiate()
+        {
+            Emit(new ThingyInitiatedEvent());
         }
 
         public void DomainErrorAfterFirst()
@@ -156,6 +162,10 @@ namespace EventFlow.TestHelpers.Aggregates
             EmitCount<ThingyUpgradableV3Event>(upgradableEventV3Count);
         }
 
+        public void Apply(ThingyInitiatedEvent aggregateEvent)
+        {
+        }
+
         public void Apply(ThingyDomainErrorAfterFirstEvent e)
         {
             DomainErrorAfterFirstReceived = true;
@@ -178,7 +188,7 @@ namespace EventFlow.TestHelpers.Aggregates
 
         void IEmit<ThingyDeletedEvent>.Apply(ThingyDeletedEvent e)
         {
-            IsDeleted = true;
+            IsThingyDeleted = true;
         }
 
         protected override Task<ThingySnapshot> CreateSnapshotAsync(CancellationToken cancellationToken)

--- a/Source/EventFlow.TestHelpers/IntegrationTest.cs
+++ b/Source/EventFlow.TestHelpers/IntegrationTest.cs
@@ -48,6 +48,8 @@ namespace EventFlow.TestHelpers
 {
     public abstract class IntegrationTest: Test
     {
+        protected Func<IServiceCollection, IServiceCollection> InjectedServices { get; set; } = new Func<IServiceCollection, IServiceCollection>((collection) => collection);
+
         protected IServiceProvider ServiceProvider { get; private set; }
         protected IAggregateStore AggregateStore { get; private set; }
         protected IEventStore EventStore { get; private set; }
@@ -65,10 +67,13 @@ namespace EventFlow.TestHelpers
         public void SetUpIntegrationTest()
         {
             var eventFlowOptions = Options(EventFlowOptions.New())
-                .RegisterServices(c => c.AddTransient<IScopedContext, ScopedContext>())
                 .AddQueryHandler<DbContextQueryHandler, DbContextQuery, string>()
                 .AddDefaults(EventFlowTestHelpers.Assembly, 
-                    type => type != typeof(DbContextQueryHandler));
+                    type => type != typeof(DbContextQueryHandler))
+                .RegisterServices(c => {
+                    c.AddTransient<IScopedContext, ScopedContext>();
+                    InjectedServices(c);
+                    });
 
             ServiceProvider = Configure(eventFlowOptions);
 

--- a/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CommandResultTests.cs
@@ -25,7 +25,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates.ExecutionResults;
 using EventFlow.Commands;
-using EventFlow.Configuration;
 using EventFlow.Extensions;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates;

--- a/Source/EventFlow.Tests/IntegrationTests/ResilienceStrategies/CreateAndDeleteStateEnforcedTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ResilienceStrategies/CreateAndDeleteStateEnforcedTests.cs
@@ -1,0 +1,149 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.EventStores;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Commands;
+using EventFlow.ResilienceStrategies;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using EventFlow.TestHelpers.Aggregates.ValueObjects;
+
+namespace EventFlow.Tests.IntegrationTests.ResilienceStrategies
+{
+    [Category(Categories.Integration)]
+    public class CreateAndDeleteStateEnforcedTests : IntegrationTest
+    {
+
+        [OneTimeSetUp]
+        public void SetDefaults()
+        {
+            InjectedServices = (collection) => collection.AddTransient<IAggregateStoreResilienceStrategy, CreateAndDeleteStateEnforcedResilienceStrategy>();
+        }
+
+        [Test]
+        public async Task InitiateCommandShouldSucceedWhenEmpty()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            var expectedAggregateVersion = 1;
+
+            // Act
+            var executionResult = await CommandBus.PublishAsync(
+                    new ThingyInitiateCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            executionResult.IsSuccess.Should().BeTrue();
+
+            // Assert
+            var thingyAggregate = await AggregateStore.LoadAsync<ThingyAggregate, ThingyId>(
+                    thingyId,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            thingyAggregate.Version.Should().Be(expectedAggregateVersion);
+        }
+
+        [Test]
+        public void NonInitiateCommandShouldFailWhenEmpty()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            var pingId = PingId.New;
+
+            // Act
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await CommandBus.PublishAsync(
+                    new ThingyPingCommand(thingyId, pingId),
+                    CancellationToken.None));
+        }
+
+        [Test]
+        public async Task InitiateCommandShouldFailWhenNotEmpty()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            await CommandBus.PublishAsync(
+                    new ThingyInitiateCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Act
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await CommandBus.PublishAsync(
+                    new ThingyInitiateCommand(thingyId),
+                    CancellationToken.None));
+        }
+
+        [Test]
+        public async Task DeleteCommandShouldChangeState()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            await CommandBus.PublishAsync(
+                    new ThingyInitiateCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Act
+            var executionResult = await CommandBus.PublishAsync(
+                    new ThingyDeleteCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            executionResult.IsSuccess.Should().BeTrue();
+
+            // Assert
+            var thingyAggregate = await AggregateStore.LoadAsync<ThingyAggregate, ThingyId>(
+                    thingyId,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            thingyAggregate.IsDeleted.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task AnyCommandShouldFailWhenDeleted()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            var pingId = PingId.New;
+
+            await CommandBus.PublishAsync(
+                    new ThingyInitiateCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            await CommandBus.PublishAsync(
+                    new ThingyDeleteCommand(thingyId),
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Act
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await CommandBus.PublishAsync(
+                    new ThingyPingCommand(thingyId, pingId),
+                    CancellationToken.None));
+        }
+    }
+}

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,6 +46,7 @@ namespace EventFlow.Aggregates
         public virtual IAggregateName Name => AggregateName;
         public TIdentity Id { get; }
         public int Version { get; protected set; }
+        public bool IsDeleted { get; protected set; }
         public virtual bool IsNew => Version <= 0;
         public IEnumerable<IUncommittedEvent> UncommittedEvents => _uncommittedEvents;
         public IEnumerable<ISourceId> PreviousSourceIds => _previousSourceIds.AsEnumerable();
@@ -67,6 +69,7 @@ namespace EventFlow.Aggregates
             }
 
             Id = id;
+            IsDeleted = false;
         }
 
         protected void SetSourceIdHistory(int count)
@@ -212,6 +215,7 @@ namespace EventFlow.Aggregates
                 applyMethod(this as TAggregate, aggregateEvent);
             }
 
+            IsDeleted = typeof(IDeletedEvent).IsAssignableFrom(eventType);
             Version++;
         }
 

--- a/Source/EventFlow/Aggregates/AggregateStore.cs
+++ b/Source/EventFlow/Aggregates/AggregateStore.cs
@@ -118,7 +118,7 @@ namespace EventFlow.Aggregates
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            await _aggregateStoreResilienceStrategy.BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+            await _aggregateStoreResilienceStrategy.BeforeAggregateLoad<TAggregate, TIdentity, TExecutionResult>(
                     id,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -136,6 +136,12 @@ namespace EventFlow.Aggregates
                     }
 
                     cancellationToken = _cancellationConfiguration.Limit(cancellationToken, CancellationBoundary.BeforeUpdatingAggregate);
+
+                    await _aggregateStoreResilienceStrategy.BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+                            aggregate,
+                            updateAggregate,
+                            cancellationToken)
+                        .ConfigureAwait(false);
 
                     var result = await updateAggregate(aggregate, c).ConfigureAwait(false);
                     if (!result.IsSuccess)

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -37,6 +37,7 @@ namespace EventFlow.Aggregates
         IEnumerable<IUncommittedEvent> UncommittedEvents { get; }
         IEnumerable<ISourceId> PreviousSourceIds { get; }
         bool IsNew { get; }
+        bool IsDeleted { get; }
 
         Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(IEventStore eventStore, ISnapshotStore snapshotStore, ISourceId sourceId, CancellationToken cancellationToken);
 

--- a/Source/EventFlow/Aggregates/IDeletedEvent.cs
+++ b/Source/EventFlow/Aggregates/IDeletedEvent.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,13 +21,10 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using EventFlow.Aggregates;
-using EventFlow.EventStores;
-
-namespace EventFlow.TestHelpers.Aggregates.Events
+namespace EventFlow.Aggregates
 {
-    [EventVersion("ThingyDeleted", 1)]
-    public class ThingyDeletedEvent : AggregateEvent<ThingyAggregate, ThingyId>, IDeletedEvent
+    public interface IDeletedEvent
     {
+        
     }
 }

--- a/Source/EventFlow/Commands/ICommandInitator.cs
+++ b/Source/EventFlow/Commands/ICommandInitator.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,13 +21,10 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using EventFlow.Aggregates;
-using EventFlow.EventStores;
-
-namespace EventFlow.TestHelpers.Aggregates.Events
+namespace EventFlow.Commands
 {
-    [EventVersion("ThingyDeleted", 1)]
-    public class ThingyDeletedEvent : AggregateEvent<ThingyAggregate, ThingyId>, IDeletedEvent
+    public interface ICommandInitator
     {
+
     }
 }

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -39,6 +39,7 @@ using EventFlow.Jobs;
 using EventFlow.Provided.Jobs;
 using EventFlow.Queries;
 using EventFlow.ReadStores;
+using EventFlow.ResilienceStrategies;
 using EventFlow.Sagas;
 using EventFlow.Sagas.AggregateSagas;
 using EventFlow.Snapshots;

--- a/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/EventStores/IAggregateStoreResilienceStrategy.cs
@@ -33,8 +33,16 @@ namespace EventFlow.EventStores
 {
     public interface IAggregateStoreResilienceStrategy
     {
-        Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+        Task BeforeAggregateLoad<TAggregate, TIdentity, TExecutionResult>(
             TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult;
+
+        Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+            TAggregate aggregate,
+            Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate,
             CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity

--- a/Source/EventFlow/ResilienceStrategies/CreateAndDeleteStateEnforcedResilienceStrategy.cs
+++ b/Source/EventFlow/ResilienceStrategies/CreateAndDeleteStateEnforcedResilienceStrategy.cs
@@ -32,7 +32,6 @@ using EventFlow.Commands;
 using EventFlow.Core;
 using EventFlow.EventStores;
 using EventFlow.Extensions;
-using EventFlow.Shims;
 
 namespace EventFlow.ResilienceStrategies
 {
@@ -49,7 +48,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
@@ -81,7 +80,7 @@ namespace EventFlow.ResilienceStrategies
                 throw new InvalidOperationException($"Aggregate '{typeof(TAggregate).PrettyPrint()}' had non-initator command '{commandType.PrettyPrint()}' when it doesn't have state");
             }
 
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task BeforeCommitAsync<TAggregate, TIdentity, TExecutionResult>(TAggregate aggregate,
@@ -91,7 +90,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task<(bool, IAggregateUpdateResult<TExecutionResult>)> HandleCommitFailedAsync<TAggregate, TIdentity,
@@ -113,7 +112,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task EventPublishSkippedAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
@@ -124,7 +123,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task BeforeEventPublishAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
@@ -135,7 +134,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         public Task<bool> HandleEventPublishFailedAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
@@ -158,7 +157,7 @@ namespace EventFlow.ResilienceStrategies
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult
         {
-            return Tasks.Completed;
+            return Task.CompletedTask;
         }
 
         private Type GetCommandType<TAggregate, TIdentity, TExecutionResult>(Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate)

--- a/Source/EventFlow/ResilienceStrategies/CreateAndDeleteStateEnforcedResilienceStrategy.cs
+++ b/Source/EventFlow/ResilienceStrategies/CreateAndDeleteStateEnforcedResilienceStrategy.cs
@@ -1,0 +1,174 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.Extensions;
+using EventFlow.Shims;
+
+namespace EventFlow.ResilienceStrategies
+{
+    public class CreateAndDeleteStateEnforcedResilienceStrategy : IAggregateStoreResilienceStrategy
+    {
+        public CreateAndDeleteStateEnforcedResilienceStrategy()
+        {
+        }
+
+        public Task BeforeAggregateLoad<TAggregate, TIdentity, TExecutionResult>(
+            TIdentity id,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+            TAggregate aggregate,
+            Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate, 
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            var commandType = GetCommandType<TAggregate, TIdentity, TExecutionResult>(updateAggregate);
+            var isInitatorCommand = typeof(ICommandInitator).IsAssignableFrom(commandType);
+
+            var actionOnDeletedAggregate = aggregate.IsDeleted;
+            if (actionOnDeletedAggregate)
+            {
+                throw new InvalidOperationException($"Aggregate '{typeof(TAggregate).PrettyPrint()}' had command '{commandType.PrettyPrint()}' when it was in a deleted state.");
+            }
+
+            var aggregateExistButShouldnt = !aggregate.IsNew && isInitatorCommand;
+            if (aggregateExistButShouldnt)
+            {
+                throw new InvalidOperationException($"Aggregate '{typeof(TAggregate).PrettyPrint()}' had initator command '{commandType.PrettyPrint()}' when it already has a state");
+            }
+
+            var aggregateDoesntExistButShould = aggregate.IsNew && !isInitatorCommand;
+            if (aggregateDoesntExistButShould)
+            {
+                throw new InvalidOperationException($"Aggregate '{typeof(TAggregate).PrettyPrint()}' had non-initator command '{commandType.PrettyPrint()}' when it doesn't have state");
+            }
+
+            return Tasks.Completed;
+        }
+
+        public Task BeforeCommitAsync<TAggregate, TIdentity, TExecutionResult>(TAggregate aggregate,
+            TExecutionResult executionResult,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task<(bool, IAggregateUpdateResult<TExecutionResult>)> HandleCommitFailedAsync<TAggregate, TIdentity,
+            TExecutionResult>(TAggregate aggregate,
+            TExecutionResult executionResult,
+            Exception exception,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Task.FromResult<(bool, IAggregateUpdateResult<TExecutionResult>)>((false, null));
+        }
+
+        public Task CommitSucceededAsync<TAggregate, TIdentity, TExecutionResult>(TAggregate aggregate,
+            TExecutionResult executionResult,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task EventPublishSkippedAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
+            TExecutionResult executionResult,
+            IReadOnlyCollection<IDomainEvent> domainEvents,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task BeforeEventPublishAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
+            TExecutionResult executionResult,
+            IReadOnlyCollection<IDomainEvent> domainEvents,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task<bool> HandleEventPublishFailedAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
+            TExecutionResult executionResult,
+            IReadOnlyCollection<IDomainEvent> domainEvents,
+            Exception exception,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task EventPublishSucceededAsync<TAggregate, TIdentity, TExecutionResult>(TIdentity id,
+            TExecutionResult executionResult,
+            IReadOnlyCollection<IDomainEvent> domainEvents,
+            CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        private Type GetCommandType<TAggregate, TIdentity, TExecutionResult>(Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            var targetMethod = updateAggregate.Target.GetType();
+            var commandField = targetMethod.GetFields().Last();
+            return commandField.GetValue(updateAggregate.Target).GetType();
+        }
+    }
+}

--- a/Source/EventFlow/ResilienceStrategies/NoAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/ResilienceStrategies/NoAggregateStoreResilienceStrategy.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using EventFlow.Aggregates;
 using EventFlow.Aggregates.ExecutionResults;
 using EventFlow.Core;
+using EventFlow.EventStores;
 
 namespace EventFlow.ResilienceStrategies
 {

--- a/Source/EventFlow/ResilienceStrategies/NoAggregateStoreResilienceStrategy.cs
+++ b/Source/EventFlow/ResilienceStrategies/NoAggregateStoreResilienceStrategy.cs
@@ -28,15 +28,24 @@ using System.Threading.Tasks;
 using EventFlow.Aggregates;
 using EventFlow.Aggregates.ExecutionResults;
 using EventFlow.Core;
+using EventFlow.EventStores;
 using EventFlow.Shims;
 
-namespace EventFlow.EventStores
+namespace EventFlow.ResilienceStrategies
 {
     public class NoAggregateStoreResilienceStrategy : IAggregateStoreResilienceStrategy
     {
-        public Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(
+        public Task BeforeAggregateLoad<TAggregate, TIdentity, TExecutionResult>(
             TIdentity id,
             CancellationToken cancellationToken)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+            return Tasks.Completed;
+        }
+
+        public Task BeforeAggregateUpdate<TAggregate, TIdentity, TExecutionResult>(TAggregate aggregate, Func<TAggregate, CancellationToken, Task<TExecutionResult>> updateAggregate, CancellationToken cancellationToken)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity
             where TExecutionResult : IExecutionResult


### PR DESCRIPTION
A common check in an aggregate is making sure that it can be initiated i.e. it hasn't been before or that you can still do actions on it i.e. it hasn't been soft-deleted.

I had implemented this previously in a slightly different manner but thought it worked nicely as a strategy