### PR TITLE
Support commands for rabbitMq

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following list key characteristics of each version as well as its related br
     - 💀 `EventFlow.Owin`
     - 🟢 `EventFlow.PostgreSql`
     - 💚 `EventFlow.Redis`
-    - 🟠 `EventFlow.RabbitMQ`
+    - 💚 `EventFlow.RabbitMQ`
     - 🟢 `EventFlow.Sql`
     - 🟠 `EventFlow.SQLite`
     - 🟢 `EventFlow.TestHelpers`

--- a/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
@@ -105,7 +105,7 @@ namespace EventFlow.RabbitMQ.Tests.Integration
             using (var consumer = new RabbitMqConsumer(_uri, exchange, new[] { "#" }))
             {
                 var resolver = BuildProvider(exchange, o => o.RegisterServices(sr =>
-                        sr.TryAddTransient<ICommandBus, RabbitMqApplicationCommandPublisher>()));
+                        sr.AddTransient<ICommandBus, RabbitMqApplicationCommandPublisher>()));
 
                 var commandBus = resolver.GetService<ICommandBus>();
                 var commandJsonSerializer = resolver.GetService<ICommandJsonSerializer>();
@@ -188,9 +188,7 @@ namespace EventFlow.RabbitMQ.Tests.Integration
             var eventFlowOptions = configure(EventFlowOptions.New()
                 .PublishToRabbitMq(RabbitMqConfiguration.With(_uri, false, exchange: exchange.Value))
                 .AddDefaults(EventFlowTestHelpers.Assembly)
-                .RegisterServices(c => c.AddTransient<IScopedContext, ScopedContext>()))
-                .RegisterServices(c => c.AddTransient<ICommandBus, RabbitMqApplicationCommandPublisher>());
-
+                .RegisterServices(c => c.AddTransient<IScopedContext, ScopedContext>()));
 
             return eventFlowOptions.ServiceCollection.BuildServiceProvider();
         }

--- a/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/Integration/RabbitMqTests.cs
@@ -27,6 +27,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Commands.Serialization;
 using EventFlow.EventStores;
 using EventFlow.Extensions;
 using EventFlow.RabbitMQ.Extensions;
@@ -71,7 +74,7 @@ namespace EventFlow.RabbitMQ.Tests.Integration
         }
 
         [Test, Retry(3)]
-        public async Task Scenario()
+        public async Task EventPublisherScenario()
         {
             var exchange = new Exchange($"eventflow-{Guid.NewGuid():N}");
             using (var consumer = new RabbitMqConsumer(_uri, exchange, new[] { "#" }))
@@ -92,6 +95,33 @@ namespace EventFlow.RabbitMQ.Tests.Integration
                     new Metadata(rabbitMqMessage.Headers));
 
                 pingEvent.AggregateEvent.PingId.Should().Be(pingId);
+            }
+        }
+
+        [Test, Retry(3)]
+        public async Task CommandPublisherScenario()
+        {
+            var exchange = new Exchange($"eventflow-{Guid.NewGuid():N}");
+            using (var consumer = new RabbitMqConsumer(_uri, exchange, new[] { "#" }))
+            {
+                var resolver = BuildProvider(exchange, o => o.RegisterServices(sr =>
+                        sr.TryAddTransient<ICommandBus, RabbitMqApplicationCommandPublisher>()));
+
+                var commandBus = resolver.GetService<ICommandBus>();
+                var commandJsonSerializer = resolver.GetService<ICommandJsonSerializer>();
+
+                var pingId = PingId.New;
+                await commandBus.PublishAsync(new ThingyPingCommand(ThingyId.New, pingId), _timeout.Token).ConfigureAwait(false);
+
+                var rabbitMqMessage = consumer.GetMessages(TimeSpan.FromMinutes(1)).Single();
+                rabbitMqMessage.Exchange.Value.Should().Be(exchange.Value);
+                rabbitMqMessage.RoutingKey.Value.Should().Be("eventflow.applicationcommand.thingy.thingy-ping.1");
+
+                var pingCommand = (ThingyPingCommand)commandJsonSerializer.Deserialize(
+                    rabbitMqMessage.Message,
+                    new CommandMetadata(rabbitMqMessage.Headers));
+
+                pingCommand.PingId.Should().Be(pingId);
             }
         }
 
@@ -158,7 +188,9 @@ namespace EventFlow.RabbitMQ.Tests.Integration
             var eventFlowOptions = configure(EventFlowOptions.New()
                 .PublishToRabbitMq(RabbitMqConfiguration.With(_uri, false, exchange: exchange.Value))
                 .AddDefaults(EventFlowTestHelpers.Assembly)
-                .RegisterServices(c => c.AddTransient<IScopedContext, ScopedContext>()));
+                .RegisterServices(c => c.AddTransient<IScopedContext, ScopedContext>()))
+                .RegisterServices(c => c.AddTransient<ICommandBus, RabbitMqApplicationCommandPublisher>());
+
 
             return eventFlowOptions.ServiceCollection.BuildServiceProvider();
         }

--- a/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
@@ -32,7 +32,6 @@ using AutoFixture;
 using Moq;
 using NUnit.Framework;
 using RabbitMQ.Client;
-using Castle.Core.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace EventFlow.RabbitMQ.Tests.UnitTests.Integrations

--- a/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/IRabbitMqMessageFactory.cs
@@ -22,11 +22,18 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Core;
 
 namespace EventFlow.RabbitMQ.Integrations
 {
     public interface IRabbitMqMessageFactory
     {
         RabbitMqMessage CreateMessage(IDomainEvent domainEvent);
+        RabbitMqMessage CreateMessage<TAggregate, TIdentity, TExecutionResult>(ICommand<TAggregate, TIdentity, TExecutionResult> applicationCommand)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult;
     }
 }

--- a/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
+++ b/Source/EventFlow.RabbitMQ/Integrations/RabbitMqPublisher.cs
@@ -55,9 +55,9 @@ namespace EventFlow.RabbitMQ.Integrations
             _transientFaultHandler = transientFaultHandler;
         }
 
-        public Task PublishAsync(CancellationToken cancellationToken, params RabbitMqMessage[] rabbitMqMessages)
+        public async Task PublishAsync(CancellationToken cancellationToken, params RabbitMqMessage[] rabbitMqMessages)
         {
-            return PublishAsync(rabbitMqMessages, cancellationToken);
+            await PublishAsync(rabbitMqMessages, cancellationToken);
         }
 
         public async Task PublishAsync(IReadOnlyCollection<RabbitMqMessage> rabbitMqMessages, CancellationToken cancellationToken)

--- a/Source/EventFlow/Commands/Serialization/CommandJsonSerializer.cs
+++ b/Source/EventFlow/Commands/Serialization/CommandJsonSerializer.cs
@@ -1,0 +1,101 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Core;
+using EventFlow.Extensions;
+
+namespace EventFlow.Commands.Serialization
+{
+    public class CommandJsonSerializer : ICommandJsonSerializer
+    {
+        private readonly IJsonSerializer _jsonSerializer;
+        private readonly ICommandDefinitionService _commandDefinitionService;
+
+        public CommandJsonSerializer(
+            IJsonSerializer jsonSerializer,
+            ICommandDefinitionService commandDefinitionService)
+        {
+            _jsonSerializer = jsonSerializer;
+            _commandDefinitionService = commandDefinitionService;
+        }
+
+        public SerializedCommand Serialize<TAggregate, TIdentity, TExecutionResult>(ICommand<TAggregate, TIdentity, TExecutionResult> applicationCommand)
+            where TAggregate : IAggregateRoot<TIdentity>
+            where TIdentity : IIdentity
+            where TExecutionResult : IExecutionResult
+        {
+
+            var commandDefinition = _commandDefinitionService.GetDefinition(applicationCommand.GetType());
+
+            var now = DateTimeOffset.Now;
+            var aggregateName = typeof(TAggregate).GetAggregateName().Value;
+
+            var metaDataPairs = new CommandMetadata()
+            {
+                SourceId = applicationCommand.SourceId,
+                CommandName = commandDefinition.Name,
+                CommandVersion = commandDefinition.Version,
+                Timestamp = now,
+                AggregateId = applicationCommand.AggregateId.Value,
+                AggregateName = aggregateName
+            };
+
+            metaDataPairs.Add(MetadataKeys.TimestampEpoch, now.ToUnixTime().ToString());
+
+            var dataJson = _jsonSerializer.Serialize(applicationCommand);
+            var metaJson = _jsonSerializer.Serialize(metaDataPairs);
+
+            return new SerializedCommand(
+                metaJson,
+                dataJson,
+                metaDataPairs);
+        }
+
+        public ICommand Deserialize(string json, ICommandMetadata metadata)
+        {
+            return Deserialize(metadata.CommandName, metadata.CommandVersion, json);
+        }
+
+        public ICommand Deserialize(string name, int version, string json)
+        {
+            var commandDefinition = _commandDefinitionService.GetDefinition(
+                name,
+                version);
+
+            ICommand command;
+            try
+            {
+                command = (ICommand)_jsonSerializer.Deserialize(json, commandDefinition.Type);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Failed to deserialize command '{name}' v{version}: {e.Message}", e);
+            }
+
+            return command;
+        }
+    }
+}

--- a/Source/EventFlow/Commands/Serialization/CommandMetadata.cs
+++ b/Source/EventFlow/Commands/Serialization/CommandMetadata.cs
@@ -1,0 +1,139 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+using System.Collections.Generic;
+using System;
+using EventFlow.Core;
+using EventFlow.Extensions;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace EventFlow.Commands.Serialization
+{
+    public class CommandMetadata : MetadataContainer, ICommandMetadata
+    {
+        public static ICommandMetadata Empty { get; } = new CommandMetadata();
+
+        public static ICommandMetadata With(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            return new CommandMetadata(keyValuePairs);
+        }
+
+        public static ICommandMetadata With(params KeyValuePair<string, string>[] keyValuePairs)
+        {
+            return new CommandMetadata(keyValuePairs);
+        }
+
+        public static ICommandMetadata With(IDictionary<string, string> keyValuePairs)
+        {
+            return new CommandMetadata(keyValuePairs);
+        }
+
+        [JsonIgnore]
+        public ISourceId SourceId
+        {
+            get => GetMetadataValue(CommandMetadataKeys.SourceId, v => new SourceId(v));
+            set => Add(CommandMetadataKeys.SourceId, value.Value);
+        }
+
+        [JsonIgnore]
+        public string CommandName
+        {
+            get => GetMetadataValue(CommandMetadataKeys.CommandName);
+            set => Add(CommandMetadataKeys.CommandName, value);
+        }
+
+        [JsonIgnore]
+        public int CommandVersion
+        {
+            get => GetMetadataValue(CommandMetadataKeys.CommandVersion, int.Parse);
+            set => Add(CommandMetadataKeys.CommandVersion, value.ToString());
+        }
+
+        [JsonIgnore]
+        public DateTimeOffset Timestamp
+        {
+            get => GetMetadataValue(CommandMetadataKeys.Timestamp, DateTimeOffset.Parse);
+            set => Add(CommandMetadataKeys.Timestamp, value.ToString("O"));
+        }
+
+        [JsonIgnore]
+        public long TimestampEpoch => TryGetValue(CommandMetadataKeys.TimestampEpoch, out var timestampEpoch)
+            ? long.Parse(timestampEpoch)
+            : Timestamp.ToUnixTime();
+
+        [JsonIgnore]
+        public string AggregateId
+        {
+            get => GetMetadataValue(CommandMetadataKeys.AggregateId);
+            set => Add(CommandMetadataKeys.AggregateId, value);
+        }
+
+        [JsonIgnore]
+        public string AggregateName
+        {
+            get => GetMetadataValue(CommandMetadataKeys.AggregateName);
+            set => Add(CommandMetadataKeys.AggregateName, value);
+        }
+
+        public CommandMetadata()
+        {
+            // Empty
+        }
+
+        public CommandMetadata(IDictionary<string, string> keyValuePairs)
+            : base(keyValuePairs)
+        {
+        }
+
+        public CommandMetadata(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+            : base(keyValuePairs.ToDictionary(kv => kv.Key, kv => kv.Value))
+        {
+        }
+
+        public CommandMetadata(params KeyValuePair<string, string>[] keyValuePairs)
+            : this((IEnumerable<KeyValuePair<string, string>>)keyValuePairs)
+        {
+        }
+
+        public ICommandMetadata CloneWith(params KeyValuePair<string, string>[] keyValuePairs)
+        {
+            return CloneWith((IEnumerable<KeyValuePair<string, string>>)keyValuePairs);
+        }
+
+        public ICommandMetadata CloneWith(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            var metadata = new CommandMetadata(this);
+            foreach (var kv in keyValuePairs)
+            {
+                if (metadata.ContainsKey(kv.Key))
+                {
+                    throw new ArgumentException($"Key '{kv.Key}' is already present!");
+                }
+                metadata[kv.Key] = kv.Value;
+            }
+            return metadata;
+        }
+    }
+}

--- a/Source/EventFlow/Commands/Serialization/CommandMetadataKeys.cs
+++ b/Source/EventFlow/Commands/Serialization/CommandMetadataKeys.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,34 +21,18 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EventFlow.Aggregates;
-using EventFlow.RabbitMQ.Integrations;
-using EventFlow.Subscribers;
 
-namespace EventFlow.RabbitMQ
+namespace EventFlow.Commands.Serialization
 {
-    public class RabbitMqDomainEventPublisher : ISubscribeSynchronousToAll
+    public sealed class CommandMetadataKeys
     {
-        private readonly IRabbitMqPublisher _rabbitMqPublisher;
-        private readonly IRabbitMqMessageFactory _rabbitMqMessageFactory;
-
-        public RabbitMqDomainEventPublisher(
-            IRabbitMqPublisher rabbitMqPublisher,
-            IRabbitMqMessageFactory rabbitMqMessageFactory)
-        {
-            _rabbitMqPublisher = rabbitMqPublisher;
-            _rabbitMqMessageFactory = rabbitMqMessageFactory;
-        }
-
-        public async Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-        {
-            var rabbitMqMessages = domainEvents.Select(e => _rabbitMqMessageFactory.CreateMessage(e)).ToList();
-
-            await _rabbitMqPublisher.PublishAsync(rabbitMqMessages, cancellationToken);
-        }
+        public const string CommandName = "command_name";
+        public const string CommandVersion = "command_version";
+        public const string Timestamp = MetadataKeys.Timestamp;
+        public const string TimestampEpoch = MetadataKeys.TimestampEpoch;
+        public const string AggregateName = MetadataKeys.AggregateName;
+        public const string AggregateId = MetadataKeys.AggregateId;
+        public const string SourceId = MetadataKeys.SourceId;
     }
 }

--- a/Source/EventFlow/Commands/Serialization/ICommandJsonSerializer.cs
+++ b/Source/EventFlow/Commands/Serialization/ICommandJsonSerializer.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,34 +21,23 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EventFlow.Aggregates;
-using EventFlow.RabbitMQ.Integrations;
-using EventFlow.Subscribers;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Core;
 
-namespace EventFlow.RabbitMQ
+namespace EventFlow.Commands.Serialization
 {
-    public class RabbitMqDomainEventPublisher : ISubscribeSynchronousToAll
+    public interface ICommandJsonSerializer
     {
-        private readonly IRabbitMqPublisher _rabbitMqPublisher;
-        private readonly IRabbitMqMessageFactory _rabbitMqMessageFactory;
+        SerializedCommand Serialize<TAggregate, TIdentity, TExecutionResult>(
+            ICommand<TAggregate, TIdentity, TExecutionResult> applicationCommand)
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TExecutionResult : IExecutionResult;
 
-        public RabbitMqDomainEventPublisher(
-            IRabbitMqPublisher rabbitMqPublisher,
-            IRabbitMqMessageFactory rabbitMqMessageFactory)
-        {
-            _rabbitMqPublisher = rabbitMqPublisher;
-            _rabbitMqMessageFactory = rabbitMqMessageFactory;
-        }
+        ICommand Deserialize(string json, ICommandMetadata metadata);
+        ICommand Deserialize(string name, int version, string json);
 
-        public async Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-        {
-            var rabbitMqMessages = domainEvents.Select(e => _rabbitMqMessageFactory.CreateMessage(e)).ToList();
-
-            await _rabbitMqPublisher.PublishAsync(rabbitMqMessages, cancellationToken);
-        }
+        //IDomainEvent Deserialize(string eventJson, string metadataJson);
     }
 }

--- a/Source/EventFlow/Commands/Serialization/ICommandMetadata.cs
+++ b/Source/EventFlow/Commands/Serialization/ICommandMetadata.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,18 +21,24 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Threading;
-using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using System.Collections.Generic;
+using System;
 using EventFlow.Core;
 
-namespace EventFlow.Commands
+namespace EventFlow.Commands.Serialization
 {
-    public interface ISerializedCommandPublisher
+    public interface ICommandMetadata : IMetadataContainer
     {
-        Task<ISourceId> PublishSerializedCommandAsync(
-            string name,
-            int version,
-            string json,
-            CancellationToken cancellationToken);
+        ISourceId SourceId { get; }
+        string CommandName { get; }
+        int CommandVersion { get; }
+        DateTimeOffset Timestamp { get; }
+        long TimestampEpoch { get; }
+        string AggregateId { get; }
+        string AggregateName { get; }
+
+        ICommandMetadata CloneWith(params KeyValuePair<string, string>[] keyValuePairs);
+        ICommandMetadata CloneWith(IEnumerable<KeyValuePair<string, string>> keyValuePairs);
     }
 }

--- a/Source/EventFlow/Commands/Serialization/ISerializedCommand.cs
+++ b/Source/EventFlow/Commands/Serialization/ISerializedCommand.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,34 +21,17 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EventFlow.Aggregates;
-using EventFlow.RabbitMQ.Integrations;
-using EventFlow.Subscribers;
+using System.Collections.Generic;
+using System;
+using EventFlow.Core;
 
-namespace EventFlow.RabbitMQ
+namespace EventFlow.Commands.Serialization
 {
-    public class RabbitMqDomainEventPublisher : ISubscribeSynchronousToAll
+    public interface ISerializedCommand
     {
-        private readonly IRabbitMqPublisher _rabbitMqPublisher;
-        private readonly IRabbitMqMessageFactory _rabbitMqMessageFactory;
-
-        public RabbitMqDomainEventPublisher(
-            IRabbitMqPublisher rabbitMqPublisher,
-            IRabbitMqMessageFactory rabbitMqMessageFactory)
-        {
-            _rabbitMqPublisher = rabbitMqPublisher;
-            _rabbitMqMessageFactory = rabbitMqMessageFactory;
-        }
-
-        public async Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-        {
-            var rabbitMqMessages = domainEvents.Select(e => _rabbitMqMessageFactory.CreateMessage(e)).ToList();
-
-            await _rabbitMqPublisher.PublishAsync(rabbitMqMessages, cancellationToken);
-        }
+        string SerializedMetadata { get; }
+        string SerializedData { get; }
+        ICommandMetadata Metadata { get; }
     }
 }

--- a/Source/EventFlow/Commands/Serialization/ISerializedCommandPublisher.cs
+++ b/Source/EventFlow/Commands/Serialization/ISerializedCommandPublisher.cs
@@ -21,34 +21,18 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EventFlow.Aggregates;
-using EventFlow.RabbitMQ.Integrations;
-using EventFlow.Subscribers;
+using EventFlow.Core;
 
-namespace EventFlow.RabbitMQ
+namespace EventFlow.Commands.Serialization
 {
-    public class RabbitMqDomainEventPublisher : ISubscribeSynchronousToAll
+    public interface ISerializedCommandPublisher
     {
-        private readonly IRabbitMqPublisher _rabbitMqPublisher;
-        private readonly IRabbitMqMessageFactory _rabbitMqMessageFactory;
-
-        public RabbitMqDomainEventPublisher(
-            IRabbitMqPublisher rabbitMqPublisher,
-            IRabbitMqMessageFactory rabbitMqMessageFactory)
-        {
-            _rabbitMqPublisher = rabbitMqPublisher;
-            _rabbitMqMessageFactory = rabbitMqMessageFactory;
-        }
-
-        public async Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-        {
-            var rabbitMqMessages = domainEvents.Select(e => _rabbitMqMessageFactory.CreateMessage(e)).ToList();
-
-            await _rabbitMqPublisher.PublishAsync(rabbitMqMessages, cancellationToken);
-        }
+        Task<ISourceId> PublishSerializedCommandAsync(
+            string name,
+            int version,
+            string json,
+            CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/Commands/Serialization/SerializedCommand.cs
+++ b/Source/EventFlow/Commands/Serialization/SerializedCommand.cs
@@ -1,4 +1,4 @@
-// The MIT License (MIT)
+﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2021 Rasmus Mikkelsen
 // Copyright (c) 2015-2021 eBay Software Foundation
@@ -21,34 +21,24 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EventFlow.Aggregates;
-using EventFlow.RabbitMQ.Integrations;
-using EventFlow.Subscribers;
 
-namespace EventFlow.RabbitMQ
+namespace EventFlow.Commands.Serialization
 {
-    public class RabbitMqDomainEventPublisher : ISubscribeSynchronousToAll
+    public class SerializedCommand : ISerializedCommand
     {
-        private readonly IRabbitMqPublisher _rabbitMqPublisher;
-        private readonly IRabbitMqMessageFactory _rabbitMqMessageFactory;
+        public string SerializedMetadata { get; }
+        public string SerializedData { get; }
+        public ICommandMetadata Metadata { get; }
 
-        public RabbitMqDomainEventPublisher(
-            IRabbitMqPublisher rabbitMqPublisher,
-            IRabbitMqMessageFactory rabbitMqMessageFactory)
+        public SerializedCommand(
+            string serializedMetadata,
+            string serializedData,
+            ICommandMetadata metadata)
         {
-            _rabbitMqPublisher = rabbitMqPublisher;
-            _rabbitMqMessageFactory = rabbitMqMessageFactory;
-        }
-
-        public async Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
-        {
-            var rabbitMqMessages = domainEvents.Select(e => _rabbitMqMessageFactory.CreateMessage(e)).ToList();
-
-            await _rabbitMqPublisher.PublishAsync(rabbitMqMessages, cancellationToken);
+            SerializedMetadata = serializedMetadata;
+            SerializedData = serializedData;
+            Metadata = metadata;
         }
     }
 }

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using EventFlow.Aggregates;
 using EventFlow.Commands;
+using EventFlow.Commands.Serialization;
 using EventFlow.Configuration;
 using EventFlow.Configuration.Cancellation;
 using EventFlow.Configuration.Serialization;
@@ -192,6 +193,7 @@ namespace EventFlow
             serviceCollection.TryAddTransient<ISnapshotUpgradeService, SnapshotUpgradeService>();
             serviceCollection.TryAddTransient<IReadModelPopulator, ReadModelPopulator>();
             serviceCollection.TryAddTransient<IEventJsonSerializer, EventJsonSerializer>();
+            serviceCollection.TryAddTransient<ICommandJsonSerializer, CommandJsonSerializer>();
             serviceCollection.TryAddTransient<IQueryProcessor, QueryProcessor>();
             serviceCollection.TryAddSingleton<IJsonSerializer, JsonSerializer>();
             serviceCollection.TryAddTransient<IJsonOptions, JsonOptions>();


### PR DESCRIPTION
**Current PR**
RabbitMq to support commands so that sagas (or other services) can receive events and send commands.

**Future Work**
A more extensive implementation can be done for out-of-the-box consumers. I started down this path but I couldn't understand a few of the concurrency decisions done previously in the publisher. For example, there is a dictionary between the URI and the respective connections, but I can't see how there would be multiple URIs.

Also, when mapping how a configurable production ready package would be, I came across EasyNetQ which could speed up the build. Any thoughts on that?