### PR TITLE
v1: Remove moq

### DIFF
--- a/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
+++ b/Source/EventFlow.RabbitMQ.Tests/UnitTests/Integrations/RabbitMqPublisherTests.cs
@@ -29,7 +29,6 @@ using EventFlow.Core;
 using EventFlow.RabbitMQ.Integrations;
 using EventFlow.TestHelpers;
 using AutoFixture;
-using Moq;
 using NUnit.Framework;
 using RabbitMQ.Client;
 using Castle.Core.Logging;
@@ -40,11 +39,11 @@ namespace EventFlow.RabbitMQ.Tests.UnitTests.Integrations
     [Category(Categories.Unit)]
     public class RabbitMqPublisherTests : TestsFor<RabbitMqPublisher>
     {
-        private Mock<IRabbitMqConnectionFactory> _rabbitMqConnectionFactoryMock;
-        private Mock<IRabbitMqConfiguration> _rabbitMqConfigurationMock;
-        private Mock<ILogger<TransientFaultHandler<IRabbitMqRetryStrategy>>> _logMock;
-        private Mock<IModel> _modelMock;
-        private Mock<IRabbitConnection> _rabbitConnectionMock;
+        private IRabbitMqConnectionFactory _rabbitMqConnectionFactoryMock;
+        private IRabbitMqConfiguration _rabbitMqConfigurationMock;
+        private ILogger<TransientFaultHandler<IRabbitMqRetryStrategy>> _logMock;
+        private IModel _modelMock;
+        private IRabbitConnection _rabbitConnectionMock;
 
         [SetUp]
         public void SetUp()
@@ -54,7 +53,7 @@ namespace EventFlow.RabbitMQ.Tests.UnitTests.Integrations
             _logMock = InjectMock<ILogger<TransientFaultHandler<IRabbitMqRetryStrategy>>>();
 
             Fixture.Inject<ITransientFaultHandler<IRabbitMqRetryStrategy>>(new TransientFaultHandler<IRabbitMqRetryStrategy>(
-                _logMock.Object,
+                _logMock,
                 new RabbitMqRetryStrategy()));
 
             var basicPropertiesMock = new Mock<IBasicProperties>();

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -17,10 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" PrivateAssets="All" />

--- a/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
+++ b/Source/EventFlow.TestHelpers/Extensions/EventStoreMockExtensions.cs
@@ -27,27 +27,27 @@ using System.Threading.Tasks;
 using EventFlow.Aggregates;
 using EventFlow.EventStores;
 using EventFlow.TestHelpers.Aggregates;
-using Moq;
+using NSubstitute;
 
 namespace EventFlow.TestHelpers.Extensions
 {
     public static class EventStoreMockExtensions
     {
         public static void Arrange_LoadEventsAsync(
-            this Mock<IEventStore> eventStoreMock,
+            this IEventStore eventStoreMock,
             params IDomainEvent<ThingyAggregate, ThingyId>[] domainEvents)
         {
             eventStoreMock
-                .Setup(s => s.LoadEventsAsync<ThingyAggregate, ThingyId>(
-                    It.IsAny<ThingyId>(),
-                    It.IsAny<CancellationToken>()))
+                .LoadEventsAsync<ThingyAggregate, ThingyId>(
+                    Arg.Any<ThingyId>(),
+                    Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IReadOnlyCollection<IDomainEvent<ThingyAggregate, ThingyId>>>(domainEvents));
 
             eventStoreMock
-                .Setup(s => s.LoadEventsAsync<ThingyAggregate, ThingyId>(
-                    It.IsAny<ThingyId>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()))
+                .LoadEventsAsync<ThingyAggregate, ThingyId>(
+                    Arg.Any<ThingyId>(),
+                    Arg.Any<int>(),
+                    Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IReadOnlyCollection<IDomainEvent<ThingyAggregate, ThingyId>>>(domainEvents));
         }
     }


### PR DESCRIPTION
The `moq` framework recently did a big no-no regarding user privacy. And while it seems the problematic code has been removed, the trust in the framework is lost. I (and thereby EventFlow) firmly believes in privacy and that developers should never need to read release notes in detail, there's simply not enough time to read ALL release notes for ALL dependencies.

Currently EventFlow is not on an affected version, but want to remove this before it needs to be updated.

References
- https://github.com/moq/moq/issues/1374
- https://github.com/dotnet/runtime/issues/90222

> To be clear, this new behavior is deeply problematic (for multiple reasons) and unacceptable for a dependency of ours.

`https://github.com/dotnet/runtime/issues/90222#issuecomment-1671834283`