### PR TITLE
Update from System.Data.SqlClient to Microsoft.Data.SqlClient in v1.x

### DIFF
--- a/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
+++ b/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
@@ -22,7 +22,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -23,12 +23,12 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using Dapper;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
 
 namespace EventFlow.MsSql.Integrations
 {

--- a/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
@@ -23,7 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using EventFlow.Core;
 using Microsoft.Extensions.Logging;

--- a/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Include="dbup-core" Version="4.1.0" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace EventFlow.TestHelpers.MsSql
 {

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using EventFlow.ValueObjects;
 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace EventFlow.TestHelpers.MsSql
 {

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace EventFlow.TestHelpers.MsSql
@@ -49,7 +49,8 @@ namespace EventFlow.TestHelpers.MsSql
                 {
                     DataSource = FirstNonEmpty(
                         Environment.GetEnvironmentVariable("EVENTFLOW_MSSQL_SERVER"),
-                        ".")
+                        "."),
+                    Encrypt = false
                 };
 
             var password = Environment.GetEnvironmentVariable("EVENTFLOW_MSSQL_PASS");
@@ -82,9 +83,10 @@ namespace EventFlow.TestHelpers.MsSql
 
             connectionStringBuilder.InitialCatalog = databaseName;
 
-            Console.WriteLine($"Using connection string for tests: {connectionStringBuilder.ConnectionString}");
+            var connectionString = connectionStringBuilder.ConnectionString;
+            Console.WriteLine($"Using connection string for tests: {connectionString}");
 
-            return new MsSqlConnectionString(connectionStringBuilder.ConnectionString);
+            return new MsSqlConnectionString(connectionString);
         }
 
         private static bool IsGoodConnectionString(string connectionString)


### PR DESCRIPTION
Details in of update in discussion: https://github.com/eventflow/EventFlow/discussions/1022#discussion-6435423

This is first PR. The second will be to `develop-v0`. Unfortunately I don't have any sample project to run tests on. Changes looks straight forward, build and unit tests passes, so there shouldn't be problems with runtime library mismatches. 

I'm currently running test on v0 version. I'll post those once finished.