### PR TITLE
v0: Update from System.Data.SqlClient to Microsoft.Data.SqlClient in v0.x 

### DIFF
--- a/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
+++ b/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
@@ -20,3 +20,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
+++ b/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>False</IsPackable>
+    <NoWarn>NU1903</NoWarn> <!-- MongoDB.Driver is outdated and update requires .NetFramework update -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -22,6 +22,7 @@
     <PackageTags>CQRS ES event sourcing MongoDB</PackageTags>
     <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
     <IsPackable>true</IsPackable>
+    <NoWarn>NU1903</NoWarn> <!-- MongoDB.Driver is outdated and update requires .NetFramework update -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
+++ b/Source/EventFlow.MsSql/Connections/MsSqlConnectionFactory.cs
@@ -21,7 +21,11 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Data;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -21,8 +21,15 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
+++ b/Source/EventFlow.MsSql/EventStores/MsSqlEventPersistence.cs
@@ -22,7 +22,11 @@
 
 using System;
 using System.Collections.Generic;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -23,12 +23,20 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using Dapper;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient.Server;
+#else
 using Microsoft.SqlServer.Server;
+#endif
 
 namespace EventFlow.MsSql.Integrations
 {

--- a/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.MsSql/RetryStrategies/MsSqlErrorRetryStrategy.cs
@@ -23,7 +23,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Linq;
 using EventFlow.Core;
 using EventFlow.Logs;

--- a/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.MsSql/SnapshotStores/MsSqlSnapshotPersistence.cs
@@ -21,7 +21,11 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/EventFlow.Owin.Tests/EventFlow.Owin.Tests.csproj
+++ b/Source/EventFlow.Owin.Tests/EventFlow.Owin.Tests.csproj
@@ -5,6 +5,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <NoWarn>NU1903</NoWarn> <!--Microsoft.Owin is outdated and update requires Autofac and a lot more to update -->
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Source/EventFlow.Owin/EventFlow.Owin.csproj
+++ b/Source/EventFlow.Owin/EventFlow.Owin.csproj
@@ -19,6 +19,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
     <IsPackable>true</IsPackable>
+    <NoWarn>NU1903</NoWarn> <!--Microsoft.Owin is outdated and update requires Autofac and a lot more to update -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
+++ b/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
@@ -22,7 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="dbup-sqlserver" Version="5.0.40" />
+    <PackageReference Condition="'$(TargetFramework)' != 'netstandard2.0'" Include="dbup-sqlserver" Version="4.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.1" />
   </ItemGroup>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -21,9 +21,16 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Dapper" Version="1.50.2" />
     <PackageReference Include="dbup-core" Version="4.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.6'" Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.ComponentModel.Annotations" Version="4.7.0" />

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/IMsSqlDatabase.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace EventFlow.TestHelpers.MsSql
 {

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using EventFlow.ValueObjects;
 

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlDatabase.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace EventFlow.TestHelpers.MsSql
 {

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace EventFlow.TestHelpers.MsSql
@@ -49,7 +49,8 @@ namespace EventFlow.TestHelpers.MsSql
                 {
                     DataSource = FirstNonEmpty(
                         Environment.GetEnvironmentVariable("EVENTFLOW_MSSQL_SERVER"),
-                        ".")
+                        "."),
+                    Encrypt = false
                 };
 
             var password = Environment.GetEnvironmentVariable("EVENTFLOW_MSSQL_PASS");
@@ -82,9 +83,10 @@ namespace EventFlow.TestHelpers.MsSql
 
             connectionStringBuilder.InitialCatalog = databaseName;
 
-            Console.WriteLine($"Using connection string for tests: {connectionStringBuilder.ConnectionString}");
+            var connectionString = connectionStringBuilder.ConnectionString;
+            Console.WriteLine($"Using connection string for tests: {connectionString}");
 
-            return new MsSqlConnectionString(connectionStringBuilder.ConnectionString);
+            return new MsSqlConnectionString(connectionString);
         }
 
         private static bool IsGoodConnectionString(string connectionString)

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -82,7 +82,7 @@ namespace EventFlow.Core
                 throw new ArgumentException("Incorrect number of arguments");
             }
 
-            var instanceArgument = Expression.Parameter(genericArguments[0]);;
+            var instanceArgument = Expression.Parameter(genericArguments[0]);
 
             var argumentPairs = funcArgumentList.Zip(methodArgumentList, (s, d) => new {Source = s, Destination = d}).ToList();
             if (argumentPairs.All(a => a.Source == a.Destination))


### PR DESCRIPTION
Details in of update in discussion: https://github.com/eventflow/EventFlow/discussions/1022#discussion-6435423

PR contains minimal set of changes to make transfer to Microsoft.Data.SqlClient successful. Threat warning as errors caused problems for valnerable packages. I've updated only `Newtonsoft.Json` as this I could test. I didn't have any MongoDB or Owin project to test on, so these are now marked with "NoWarn" option. I could try to update those also, but in this case I'd go with Yurii's [PR and update all](https://github.com/eventflow/EventFlow/pull/1023).