### PR TITLE
Fix ReadModelSqlGenerator column prefix and suffix usage [Copilot workspare test]

### DIFF
--- a/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2024 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using EventFlow.PostgreSql.ReadModels;
 using EventFlow.Sql.ReadModels;
 using EventFlow.ReadStores;

--- a/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
@@ -1,0 +1,69 @@
+using EventFlow.PostgreSql.ReadModels;
+using EventFlow.Sql.ReadModels;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.PostgreSql.Tests.UnitTests
+{
+    [TestFixture]
+    public class ReadModelSqlGeneratorTests
+    {
+        [Test]
+        public void PostgresReadModelSqlGenerator_ApplyColumnPrefixesAndSuffixesInSelectQueries()
+        {
+            // Arrange
+            var readModelSqlGenerator = new PostgresReadModelSqlGenerator();
+
+            // Act
+            var selectSql = readModelSqlGenerator.CreateSelectSql<TestReadModel>();
+
+            // Assert
+            selectSql.Should().Contain("\"Id\" = @EventFlowReadModelId");
+        }
+
+        [Test]
+        public void PostgresReadModelSqlGenerator_ApplyColumnPrefixesAndSuffixesInInsertQueries()
+        {
+            // Arrange
+            var readModelSqlGenerator = new PostgresReadModelSqlGenerator();
+
+            // Act
+            var insertSql = readModelSqlGenerator.CreateInsertSql<TestReadModel>();
+
+            // Assert
+            insertSql.Should().Contain("\"Id\", \"Name\"");
+        }
+
+        [Test]
+        public void PostgresReadModelSqlGenerator_ApplyColumnPrefixesAndSuffixesInUpdateQueries()
+        {
+            // Arrange
+            var readModelSqlGenerator = new PostgresReadModelSqlGenerator();
+
+            // Act
+            var updateSql = readModelSqlGenerator.CreateUpdateSql<TestReadModel>();
+
+            // Assert
+            updateSql.Should().Contain("\"Id\" = @Id");
+        }
+
+        [Test]
+        public void PostgresReadModelSqlGenerator_ApplyColumnPrefixesAndSuffixesInDeleteQueries()
+        {
+            // Arrange
+            var readModelSqlGenerator = new PostgresReadModelSqlGenerator();
+
+            // Act
+            var deleteSql = readModelSqlGenerator.CreateDeleteSql<TestReadModel>();
+
+            // Assert
+            deleteSql.Should().Contain("\"Id\" = @EventFlowReadModelId");
+        }
+
+        public class TestReadModel : IReadModel
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
@@ -1,5 +1,6 @@
 using EventFlow.PostgreSql.ReadModels;
 using EventFlow.Sql.ReadModels;
+using EventFlow.ReadStores;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/UnitTests/ReadModelSqlGeneratorTests.cs
@@ -41,7 +41,7 @@ namespace EventFlow.PostgreSql.Tests.UnitTests
             var selectSql = readModelSqlGenerator.CreateSelectSql<TestReadModel>();
 
             // Assert
-            selectSql.Should().Contain("\"Id\" = @EventFlowReadModelId");
+            selectSql.Should().Contain("\"AggregateId\" = @EventFlowReadModelId");
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace EventFlow.PostgreSql.Tests.UnitTests
             var insertSql = readModelSqlGenerator.CreateInsertSql<TestReadModel>();
 
             // Assert
-            insertSql.Should().Contain("\"Id\", \"Name\"");
+            insertSql.Should().Contain("\"AggregateId\", \"Name\"");
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace EventFlow.PostgreSql.Tests.UnitTests
             var updateSql = readModelSqlGenerator.CreateUpdateSql<TestReadModel>();
 
             // Assert
-            updateSql.Should().Contain("\"Id\" = @Id");
+            updateSql.Should().Contain("\"AggregateId\" = @Id");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace EventFlow.PostgreSql.Tests.UnitTests
             var deleteSql = readModelSqlGenerator.CreateDeleteSql<TestReadModel>();
 
             // Assert
-            deleteSql.Should().Contain("\"Id\" = @EventFlowReadModelId");
+            deleteSql.Should().Contain("\"AggregateId\" = @EventFlowReadModelId");
         }
 
         public class TestReadModel : IReadModel

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
@@ -101,7 +101,7 @@ namespace EventFlow.Sql.ReadModels
             var tableName = GetTableName<TReadModel>();
             var identityColumn = GetIdentityColumn<TReadModel>();
 
-            sql = $"SELECT * FROM {tableName} WHERE {identityColumn} = @EventFlowReadModelId";
+            sql = $"SELECT * FROM {tableName} WHERE {Configuration.ColumnQuotedIdentifierPrefix}{identityColumn}{Configuration.ColumnQuotedIdentifierSuffix} = @EventFlowReadModelId";
 
             _selectSqls[readModelType] = sql;
 


### PR DESCRIPTION
Related to #1002

This pull request addresses the issue with the `ReadModelSqlGenerator` not correctly applying column prefix and suffix in the select query for PostgreSQL read models. The changes ensure that column and table identifiers are properly quoted according to PostgreSQL standards, thus resolving the error encountered when working with read models.

- **SQL Generation Adjustments**: Modifies the `CreateSelectSql` method in `ReadModelSqlGenerator.cs` to utilize `ColumnQuotedIdentifierPrefix` and `ColumnQuotedIdentifierSuffix` for column names, ensuring all column names in the SELECT query are correctly quoted.
- **Unit Testing**: Adds new unit tests in `ReadModelSqlGeneratorTests.cs` under `EventFlow.PostgreSql.Tests` to verify that `PostgresReadModelSqlGenerator` correctly applies column prefixes and suffixes in SELECT, INSERT, UPDATE, and DELETE queries.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eventflow/EventFlow/issues/1002?shareId=2a435325-fba7-4f60-af5b-2b4bf39b6f0e).