### PR TITLE
v0: Upgrade MongoDB.Driver to 2.28

### DIFF
--- a/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
+++ b/Source/EventFlow.MongoDB.Tests/EventFlow.MongoDB.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
-    <PackageReference Include="Mongo2Go" Version="2.2.12" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageReference Include="Mongo2Go" Version="3.1.3" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <PackageId>EventFlow.MongoDB</PackageId>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded target frameworks to match targets of Mongo 2.28 in v0. Tests pass.

Resolves Issue #1038.

Thanks!