### PR TITLE
V1: Update dbup-core in .net6 and newer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
   - MongoDB
   - MSSQL
   - PostgreSQL
-* Breaking: `EventFlow.Sql` from .NET 6 and above uses dbup version 6 to migrate databases.
+* Breaking: `EventFlow.Sql` from .NET 8 and above uses dbup version 6 to migrate databases.
 
 *Sorry for the delay.*
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
   - MongoDB
   - MSSQL
   - PostgreSQL
+* Breaking: `EventFlow.Sql` from .NET 6 and above uses dbup version 6 to migrate databases.
 
 *Sorry for the delay.*
 

--- a/Source/EventFlow.EntityFramework.Tests/EventFlow.EntityFramework.Tests.csproj
+++ b/Source/EventFlow.EntityFramework.Tests/EventFlow.EntityFramework.Tests.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Npgsql" Version="8.0.6" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/Source/EventFlow.MsSql.Tests/EventFlow.MsSql.Tests.csproj
+++ b/Source/EventFlow.MsSql.Tests/EventFlow.MsSql.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/EventFlow.MsSql.Tests/EventFlow.MsSql.Tests.csproj
+++ b/Source/EventFlow.MsSql.Tests/EventFlow.MsSql.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Title>EventFlow.MsSql</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
@@ -12,9 +12,27 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="dbup-sqlserver" Version="[6.0.0,)" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
+++ b/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Title>EventFlow.PostgreSql</Title>
     <Authors>Rida Messaoudene</Authors>
     <Company>Rasmus Mikkelsen</Company>
@@ -25,8 +25,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-postgresql" Version="4.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="dbup-postgresql" Version="[6.0.3,)" />
+    <PackageReference Include="Npgsql" Version="[9.0.2,)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="dbup-postgresql" Version="5.0.40" />
+    <PackageReference Include="Npgsql" Version="4.1.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="dbup-postgresql" Version="5.0.40" />
+    <PackageReference Include="Npgsql" Version="4.1.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="dbup-postgresql" Version="5.0.40" />
     <PackageReference Include="Npgsql" Version="4.1.14" />
   </ItemGroup>
 

--- a/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
+++ b/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
@@ -9,9 +9,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="dbup-sqlserver" Version="[6.0.0,)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -4,7 +4,7 @@
     <Title>EventFlow.Sql</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2021</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2025</Copyright>
     <Description>Generic SQL support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing SQL</PackageTags>
     <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
@@ -13,9 +13,24 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="dbup-core" Version="5.0.37" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="dbup-core" Version="[6.0.0,)" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="dbup-core" Version="[6.0.0,)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="dbup-core" Version="5.0.87" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="dbup-core" Version="5.0.87" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="dbup-core" Version="[6.0.0,)" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -26,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="dbup-core" Version="5.0.87" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="dbup-core" Version="5.0.87" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -64,7 +64,7 @@ namespace EventFlow.Sql.Integrations
 
         public void LogError(Exception ex, string format, params object[] args)
         {
-            _logger.LogError(format, args);
+            _logger.LogError(ex, format, args);
         }
     }
 #else

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -20,12 +20,55 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using DbUp.Engine.Output;
 using Microsoft.Extensions.Logging;
 
 namespace EventFlow.Sql.Integrations
 {
+#if NET6_0_OR_GREATER
     public class DbUpUpgradeLog : IUpgradeLog
+    {
+        private readonly ILogger _logger;
+
+        public DbUpUpgradeLog(
+            ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void LogTrace(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void LogDebug(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void LogInformation(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void LogWarning(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void LogError(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void LogError(Exception ex, string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+    }
+#else
+public class DbUpUpgradeLog : IUpgradeLog
     {
         private readonly ILogger _logger;
 
@@ -50,4 +93,5 @@ namespace EventFlow.Sql.Integrations
             _logger.LogError(format, args);
         }
     }
+#endif
 }

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -26,7 +26,6 @@ using Microsoft.Extensions.Logging;
 
 namespace EventFlow.Sql.Integrations
 {
-#if NET6_0_OR_GREATER
     public class DbUpUpgradeLog : IUpgradeLog
     {
         private readonly ILogger _logger;
@@ -66,17 +65,6 @@ namespace EventFlow.Sql.Integrations
         {
             _logger.LogError(ex, format, args);
         }
-    }
-#else
-public class DbUpUpgradeLog : IUpgradeLog
-    {
-        private readonly ILogger _logger;
-
-        public DbUpUpgradeLog(
-            ILogger logger)
-        {
-            _logger = logger;
-        }
 
         public void WriteInformation(string format, params object[] args)
         {
@@ -93,5 +81,4 @@ public class DbUpUpgradeLog : IUpgradeLog
             _logger.LogError(format, args);
         }
     }
-#endif
 }


### PR DESCRIPTION
In dbup-core version 6 and later a breaking change was made in the logger. Version 6 also includes the logger abstractions package, that does not support the old .net core or standard versions.

This PR updates dbup-core to version 6 when running .net6 or newer