### PR TITLE
Fix multiple calls of the same async subscribers when dispatching events

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### New in 1.2.1 (working version, not released yet)
 
-* *Nothing yet...*
+* Fix: Prevent multiple calls of the same async subscribers when dispatching events (by @alexeyfv)
 
 ### New in 1.2.0 (released 2025-03-09)
 

--- a/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
+++ b/Source/EventFlow/Subscribers/DispatchToEventSubscribers.cs
@@ -127,6 +127,8 @@ namespace EventFlow.Subscribers
                 .ConfigureAwait(false);
             var subscribers = _serviceProvider.GetServices(subscriberInformation.SubscriberType)
                 .Cast<ISubscribe>()
+                .GroupBy(s => s.GetType())
+                .Select(g => g.First())
                 .OrderBy(s => s.GetType().Name)
                 .ToList();
 


### PR DESCRIPTION
Hi,

I found the issue with async subscribers (#1074). When using the `AddDefaults` method, it registers the same subscriber multiple times. During event dispatching, duplicates were not removed, causing the same subscriber to be invoked multiple times.

Let me know if you have any feedback.