### PR TITLE
 fix/1095 - Add EventFlowMongoInitializer for MongoDB setup 

### DIFF
--- a/Source/EventFlow.MongoDB/EventStore/EventFlowMongoInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/EventFlowMongoInitializer.cs
@@ -1,3 +1,25 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2025 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;

--- a/Source/EventFlow.MongoDB/EventStore/EventFlowMongoInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/EventFlowMongoInitializer.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EventFlow.MongoDB.EventStore
+{
+    public class EventFlowMongoInitializer
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public EventFlowMongoInitializer(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void Initialize()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var initializer = scope.ServiceProvider.GetRequiredService<IMongoDbEventPersistenceInitializer>();
+            initializer.Initialize();
+        }
+    }
+}


### PR DESCRIPTION
Introduces the `EventFlowMongoInitializer` class in the `EventFlow.MongoDB.EventStore` namespace. This class facilitates the initialization of MongoDB event persistence by utilizing an `IServiceProvider` to manage dependencies and service lifetimes. The `Initialize` method creates a scope and retrieves an instance of `IMongoDbEventPersistenceInitializer` to perform the necessary setup.
Add your 'Program.cs' 
`builder.Services.AddEventFlow(options => options
    .ConfigureMongoDb("your_connection_string", "your_db")
    .UseMongoDbEventStore()
);
var sp = builder.Services.BuildServiceProvider();
var efInitializer = new EventFlowMongoInitializer(sp);
efInitializer.Initialize();`
Close #1095 